### PR TITLE
Align image numpy to be similar to those from ITK and NiBabel

### DIFF
--- a/monai/deploy/operators/dicom_series_to_volume_operator.py
+++ b/monai/deploy/operators/dicom_series_to_volume_operator.py
@@ -52,9 +52,8 @@ class DICOMSeriesToVolumeOperator(Operator):
             A 3D numpy tensor rerepesenting the volumetric data.
         """
         slices = series.get_sop_instances()
-        # Need to transpose the DICOM pixel_array and pack the slice as the last dim,
-        # so the pixels are arranged in HWD. This is to have the same numpy ndarray
-        # as from Monai ImageReader (ITK, Nibabel etc).
+        # Need to transpose the DICOM pixel_array and pack the slice as the last dim.
+        # This is to have the same numpy ndarray as from Monai ImageReader (ITK, NiBabel etc).
         vol_data = np.stack([np.transpose(s.get_pixel_array()) for s in slices], axis=-1)
         vol_data = vol_data.astype(np.int16)
         intercept = slices[0][0x0028, 0x1052].value

--- a/monai/deploy/operators/png_converter_operator.py
+++ b/monai/deploy/operators/png_converter_operator.py
@@ -32,7 +32,7 @@ from monai.deploy.operators.dicom_series_to_volume_operator import DICOMSeriesTo
 
 from monai.deploy.core.domain.image import Image
 
-from os import listdir
+from os import listdir, makedirs
 from os.path import isfile, join
 
 import math
@@ -70,24 +70,22 @@ class PNGConverterOperator(Operator):
         num_images = image_shape[0]
 
         for i in range( 0, num_images):
-            input_data = image_data[i, :, :]
+            input_data = image_data[:, :, i]
             pil_image=PILImage.fromarray(input_data)
             if pil_image.mode != 'RGB':
                 pil_image = pil_image.convert('RGB')
-            pil_image.save(str(path) + "/" + str(i) + ".png")
-
-    
+            pil_image.save(join(str(path), join(str(i) + ".png")))
 
 
 def main():
     op1 = DICOMSeriesToVolumeOperator()
     data_path = "/home/rahul/medical-images/lung-ct-2/"
     out_path = "/home/rahul/monai-output/"
-
+    makedirs(out_path, exist_ok=True)
 
     files = []
     loader = DICOMDataLoaderOperator()
-    loader._list_files(files, data_path)
+    loader._list_files(data_path, files,)
     study_list = loader._load_data(files)
 
     series = study_list[0].get_all_series()[0]
@@ -97,7 +95,7 @@ def main():
     image = op1.create_volumetric_image(voxels, metadata)
 
     op2 = PNGConverterOperator()
-    op2.convert_and_save(image, out_path, -200, -2000)
+    op2.convert_and_save(image, out_path)
 
     print(series)
     #print(metadata.keys())


### PR DESCRIPTION
This is to address the following issues during integrating SDK `DICOMSeriesToVolumeOperator`:
1. Each slice's 2D numpy ndarray is set with pydicom `pixel_array `(numpy) in the instance object that has been read using `pydicom.dcmread`. This ndarray's dims are switched compared to ITK (`array_view_from_image`) on the same set of dcm files, as well as the ndarray from NiBabel on the NIfTI file representing the same DICOM Series.
2. The instances are added as the first dim, but it should be the last
3. The Image class right now does not have its own internal representation of a image, aside from a placeholder for an `ArrayLike `object, and an `asnumpy()` method simply returns the `ArrayLike `object. Not much can be done here before this class is fully designed.

So, for now, it is best to arrange the numpy array dims in the creator of the array,  `DICOMSeriesToVolumeOperator`, to make it compatible with that from ITK and NiBabel.
Also updated the `PNGConverterOperator `to make use of updated APIs.