### PR TITLE
Allow inheriting decorated class

### DIFF
--- a/examples/apps/simple_imaging_app/median_operator.py
+++ b/examples/apps/simple_imaging_app/median_operator.py
@@ -1,4 +1,4 @@
-# Copyright 2020 - 2021 MONAI Consortium
+# Copyright 2021 MONAI Consortium
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -16,8 +16,8 @@ from monai.deploy.core import ExecutionContext, Image, InputContext, IOType, Ope
 @output("image", Image, IOType.IN_MEMORY)
 # If `pip_packages` is specified, the definition will be aggregated with the package dependency list of other
 # operators and the application in packaging time.
-# @env(pip_packages=["scikit-image >= 0.18.0"])
-class MedianOperator(Operator):
+# @env(pip_packages=["scikit-image >= 0.17.2"])
+class MedianOperatorBase(Operator):
     """This Operator implements a noise reduction.
 
     The algorithm is based on the median operator.
@@ -25,6 +25,16 @@ class MedianOperator(Operator):
     """
 
     def compute(self, input: InputContext, output: OutputContext, context: ExecutionContext):
+        print("Executing base operator...")
+
+
+class MedianOperator(MedianOperatorBase):
+    """This operator is a subclass of the base operator to demonstrate the usage of inheritance."""
+
+    def compute(self, input: InputContext, output: OutputContext, context: ExecutionContext):
+        # Execute the base operator's compute method.
+        super().compute(input, output, context)
+
         from skimage.filters import median
 
         # Get a model instance if exists

--- a/monai/deploy/core/application.py
+++ b/monai/deploy/core/application.py
@@ -1,4 +1,4 @@
-# Copyright 2020 - 2021 MONAI Consortium
+# Copyright 2021 MONAI Consortium
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os.path
 import sys
 from abc import ABC, abstractmethod
 from pathlib import Path
@@ -47,7 +46,10 @@ class Application(ABC):
     # Application's version. <git version tag> or '0.0.0' if not specified.
     version: str = ""
 
-    # Special attribute to identify the application
+    # Special attribute to identify the application.
+    # Used by the CLI executing get_application() or is_application() from deploy.utils.importutil to
+    # determine the application to run.
+    # This is needed to identify Application class across different environments (e.g. by `runpy.run_path()`).
     _class_id: str = "monai.application"
 
     def __init__(
@@ -116,6 +118,17 @@ class Application(ABC):
     @classmethod
     def __subclasshook__(cls, c: Type) -> bool:
         return is_application(c)
+
+    def _builder(self):
+        """This method is called by the constructor of Application to set up the operator.
+
+        This method returns `self` to allow for method chaining and new `_builder()` method is
+        chained by decorators.
+
+        Returns:
+            An instance of Application.
+        """
+        return self
 
     @property
     def context(self) -> AppContext:


### PR DESCRIPTION
If an operator class was decorated and the operator class is subclassed
by other classes, it causes errors because the current decorator returns
a function, not a class.

```
   TypeError: function() argument 1 must be code, not str
```

Example>

```python
  @input("image", Image, IOType.IN_MEMORY)
  @output("seg_image", Image, IOType.IN_MEMORY)
  class MonaiInferenceOperator(Operator):
      ...

  class SpleenSegOperator(MonaiInferenceOperator):
      ...
```

This patch solves the issue by returning class instead of a method.
It also uses a special builder method `_builder()` to chain methods
to set an operator or an application.