### PR TITLE
Update annotations to support Python 3.6

### DIFF
--- a/examples/apps/simple_imaging_app/app.py
+++ b/examples/apps/simple_imaging_app/app.py
@@ -1,4 +1,4 @@
-# Copyright 2020 - 2021 MONAI Consortium
+# Copyright 2021 MONAI Consortium
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -18,7 +18,7 @@ from monai.deploy.core import Application, env, resource
 
 @resource(cpu=1)
 # pip_packages can be a string that is a path(str) to requirements.txt file or a list of packages.
-@env(pip_packages=["scikit-image >= 0.18.0"])
+@env(pip_packages=["scikit-image >= 0.17.2"])
 class App(Application):
     """This is a very basic application.
 

--- a/examples/apps/simple_imaging_app/gaussian_operator.py
+++ b/examples/apps/simple_imaging_app/gaussian_operator.py
@@ -1,4 +1,4 @@
-# Copyright 2020 - 2021 MONAI Consortium
+# Copyright 2021 MONAI Consortium
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -26,7 +26,7 @@ from monai.deploy.core import (
 @output("image", DataPath, IOType.DISK)
 # If `pip_packages` is specified, the definition will be aggregated with the package dependency list of other
 # operators and the application in packaging time.
-# @env(pip_packages=["scikit-image >= 0.18.0"])
+# @env(pip_packages=["scikit-image >= 0.17.2"])
 class GaussianOperator(Operator):
     """This Operator implements a smoothening based on Gaussian.
 

--- a/examples/apps/simple_imaging_app/requirements.txt
+++ b/examples/apps/simple_imaging_app/requirements.txt
@@ -1,1 +1,1 @@
-scikit-image >= 0.18.0
+scikit-image >= 0.17.2

--- a/examples/apps/simple_imaging_app/sobel_operator.py
+++ b/examples/apps/simple_imaging_app/sobel_operator.py
@@ -1,4 +1,4 @@
-# Copyright 2020 - 2021 MONAI Consortium
+# Copyright 2021 MONAI Consortium
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -26,7 +26,7 @@ from monai.deploy.core import (
 @output("image", Image, IOType.IN_MEMORY)
 # If `pip_packages` is specified, the definition will be aggregated with the package dependency list of other
 # operators and the application in packaging time.
-# @env(pip_packages=["scikit-image >= 0.18.0"])
+# @env(pip_packages=["scikit-image >= 0.17.2"])
 class SobelOperator(Operator):
     """This Operator implements a Sobel edge detector.
 

--- a/monai/deploy/core/domain/dicom_sop_instance.py
+++ b/monai/deploy/core/domain/dicom_sop_instance.py
@@ -1,4 +1,4 @@
-# Copyright 2020 - 2021 MONAI Consortium
+# Copyright 2021 MONAI Consortium
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -36,7 +36,7 @@ class DICOMSOPInstance(Domain):
     def get_native_sop_instance(self):
         return self._sop
 
-    def __getitem__(self, key: Union[int, slice, TagType]) -> Union[Dataset, DataElement]:
+    def __getitem__(self, key: Union[int, slice, "TagType"]) -> Union["Dataset", "DataElement"]:
         return self._sop.__getitem__(key)
 
     def get_pixel_array(self):

--- a/monai/deploy/core/execution_context.py
+++ b/monai/deploy/core/execution_context.py
@@ -1,4 +1,4 @@
-# Copyright 2020 - 2021 MONAI Consortium
+# Copyright 2021 MONAI Consortium
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -8,8 +8,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional, Type
 
@@ -44,7 +42,7 @@ class BaseExecutionContext:
 class ExecutionContext(BaseExecutionContext):
     """An execution context for the operator."""
 
-    def __init__(self, context: BaseExecutionContext, op: Operator):
+    def __init__(self, context: BaseExecutionContext, op: "Operator"):
         super().__init__(context.storage, context.models)
         self._context = context
         self._op = op

--- a/monai/deploy/core/executors/executor.py
+++ b/monai/deploy/core/executors/executor.py
@@ -1,4 +1,4 @@
-# Copyright 2020 - 2021 MONAI Consortium
+# Copyright 2021 MONAI Consortium
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -8,8 +8,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Optional
@@ -23,7 +21,7 @@ from monai.deploy.core.datastores import Datastore, DatastoreFactory
 class Executor(ABC):
     """This is the base class that enables execution of an application."""
 
-    def __init__(self, app: Application, datastore: Optional[Datastore] = None):
+    def __init__(self, app: "Application", datastore: Optional[Datastore] = None):
         """Constructor of the class.
 
         Given an application it invokes the compose method on the app, which
@@ -40,7 +38,7 @@ class Executor(ABC):
             self._datastore = DatastoreFactory.create(DatastoreFactory.DEFAULT)
 
     @property
-    def app(self) -> Application:
+    def app(self) -> "Application":
         """Returns the application that is executed by the executor."""
         return self._app
 

--- a/monai/deploy/core/executors/single_process_executor.py
+++ b/monai/deploy/core/executors/single_process_executor.py
@@ -1,4 +1,4 @@
-# Copyright 2020 - 2021 MONAI Consortium
+# Copyright 2021 MONAI Consortium
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -9,8 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-from __future__ import annotations
 
 import os
 

--- a/monai/deploy/core/io_context.py
+++ b/monai/deploy/core/io_context.py
@@ -1,4 +1,4 @@
-# Copyright 2020 - 2021 MONAI Consortium
+# Copyright 2021 MONAI Consortium
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -8,8 +8,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from __future__ import annotations
 
 from abc import ABC
 from typing import TYPE_CHECKING, Any
@@ -25,7 +23,7 @@ class IOContext(ABC):
 
     _io_kind = "undefined"
 
-    def __init__(self, execution_context: ExecutionContext):
+    def __init__(self, execution_context: "ExecutionContext"):
         """Constructor for IOContext."""
         self._execution_context = execution_context
         self._op = execution_context.op

--- a/monai/deploy/core/models/model.py
+++ b/monai/deploy/core/models/model.py
@@ -1,4 +1,4 @@
-# Copyright 2020 - 2021 MONAI Consortium
+# Copyright 2021 MONAI Consortium
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -8,7 +8,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import annotations
 
 import os.path
 from pathlib import Path
@@ -143,7 +142,7 @@ class Model:
             return False, None
         return True, cls.model_type
 
-    def get(self, name: str = "") -> Optional[Type[Model]]:
+    def get(self, name: str = "") -> Optional[Type["Model"]]:
         """Return a model object by name.
 
         If there is only one model in the repository or the model path, model object can be returned without specifying
@@ -192,7 +191,7 @@ class Model:
 
         return model_list
 
-    def items(self) -> ItemsView[str, Type[Model]]:
+    def items(self) -> ItemsView[str, Type["Model"]]:
         """Return an ItemsView of models that this Model instance has.
 
         If this model represents a model repository, then an ItemsView of submodel objects is returned.

--- a/monai/deploy/utils/importutil.py
+++ b/monai/deploy/utils/importutil.py
@@ -1,4 +1,4 @@
-# Copyright 2020 - 2021 MONAI Consortium
+# Copyright 2021 MONAI Consortium
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -8,8 +8,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from __future__ import annotations
 
 import inspect
 import runpy
@@ -54,7 +52,7 @@ def is_application(cls: Any) -> bool:
     return False
 
 
-def get_application(path: Union[str, Path]) -> Optional[Application]:
+def get_application(path: Union[str, Path]) -> Optional["Application"]:
     """Get application object from path."""
 
     if isinstance(path, str):

--- a/requirements-examples.txt
+++ b/requirements-examples.txt
@@ -1,1 +1,1 @@
-scikit-image >= 0.18.0
+scikit-image >= 0.17.2


### PR DESCRIPTION
- Do not use `from __future__ import annotations` as Python 3.6 doesn't
  have it.
- Use string for annotation if needed.
- Install scikit-image >= 0.17.2 as it is the latest version that
  Python 3.6 support.