### PR TITLE
Fix missing self._build() call in the application

### DIFF
--- a/monai/deploy/core/application.py
+++ b/monai/deploy/core/application.py
@@ -105,6 +105,9 @@ class Application(ABC):
 
         self._graph: Graph = GraphFactory.create(context.graph)
 
+        # Execute the builder to set up the application
+        self._builder()
+
         # Compose operators
         self.compose()
 


### PR DESCRIPTION
Calling `self._build()` was missing in the previous patch #49 
