### PR TITLE
Fix inheritance issue for Operator and Application

### DIFF
--- a/examples/apps/simple_imaging_app/median_operator.py
+++ b/examples/apps/simple_imaging_app/median_operator.py
@@ -24,12 +24,22 @@ class MedianOperatorBase(Operator):
     It ingests a single input and provides a single output.
     """
 
+    # Define __init__ method with super().__init__() if you want to override the default behavior.
+    def __init__(self):
+        super().__init__()
+        # Do something
+
     def compute(self, input: InputContext, output: OutputContext, context: ExecutionContext):
         print("Executing base operator...")
 
 
 class MedianOperator(MedianOperatorBase):
     """This operator is a subclass of the base operator to demonstrate the usage of inheritance."""
+
+    # Define __init__ method with super().__init__() if you want to override the default behavior.
+    def __init__(self):
+        super().__init__()
+        # Do something
 
     def compute(self, input: InputContext, output: OutputContext, context: ExecutionContext):
         # Execute the base operator's compute method.

--- a/monai/deploy/core/env.py
+++ b/monai/deploy/core/env.py
@@ -69,7 +69,7 @@ def env(pip_packages: Optional[Union[str, List[str]]] = None):
     from .operator import Operator, OperatorEnv
 
     def decorator(cls):
-        if hasattr(cls, "_env"):
+        if hasattr(cls, "_env") and cls._env:
             raise ItemAlreadyExistsError(f"@env decorator is aleady specified for {cls}.")
 
         if issubclass(cls, Operator):

--- a/monai/deploy/core/resource.py
+++ b/monai/deploy/core/resource.py
@@ -126,7 +126,7 @@ def resource(
                 raise ItemAlreadyExistsError(f"In @resource decorator at {self.name}, {e.args[0]}")
 
             return self
-
-        return type(cls.__name__, cls.__bases__, dict(cls.__dict__, _builder=new_builder))
+        cls._builder = new_builder
+        return cls
 
     return decorator

--- a/monai/deploy/utils/importutil.py
+++ b/monai/deploy/utils/importutil.py
@@ -43,9 +43,20 @@ def get_docstring(cls: type) -> str:
     return "\n".join([line.strip() for line in doc.split("\n")])
 
 
-def is_application(cls: Any) -> bool:
-    """Check if the given type is a subclass of Application class."""
-    if hasattr(cls, "_class_id") and cls._class_id == "monai.application":
+def is_subclass(cls: type, class_or_tuple: Union[str, Tuple[str]]) -> bool:
+    """Check if the given type is a subclass of a MONAI App SDK class.
+
+    Args:
+        cls (type): A class to check.
+        class_or_tuple (Union[str, Tuple[str]]): A class name or a tuple of class names.
+
+    Returns:
+        True if the given class is a subclass of the given class or one of the classes in the tuple.
+    """
+    if type(class_or_tuple) is str:
+        class_or_tuple  = (class_or_tuple,)
+
+    if hasattr(cls, "_class_id") and cls._class_id in class_or_tuple:
         if inspect.isclass(cls) and hasattr(cls, "__abstractmethods__") and len(cls.__abstractmethods__) != 0:
             return False
         return True


### PR DESCRIPTION
Previously, a new type that overrides was returned by @input @output
@env decorators which can cause the following error when executing
super() method in `__init__()`:

```python
@input("image", Image, IOType.IN_MEMORY)
@output("image", Image, IOType.IN_MEMORY)
class MedianOperatorBase(Operator):
    def __init__(self):
        super().__init__()
```

```
TypeError: super(type, obj): obj must be an instance or subtype of type
```

We don't need to create a new type (with the same name).
Instead, just override _builder property to achieve the same behavior.

You can find the similar issue at https://stackoverflow.com/a/52927102/16361228

Also, this patch does not set _env in the constructor of Application
and Operator. Instead it is set to None by default in the class
definition and check if has a value or not in @env decorator.