### PR TITLE
Added nibabel as runtime dependency as it's required by Monai transforms

### DIFF
--- a/examples/apps/ai_spleen_seg_app/app.py
+++ b/examples/apps/ai_spleen_seg_app/app.py
@@ -65,7 +65,7 @@ if __name__ == "__main__":
     # Creates the app and test it standalone.
     # Model file is expected to be at: model/model.ts
     # Input DICOM CT series is expected to be in: input/
-    # Output of DICOM Seg instance is to be in: /output
+    # Output of DICOM Seg instance is to be in: output/
     #
     logging.basicConfig(level=logging.DEBUG)
     app_instance = AISpleenSegApp()  # Optional params' defaults are fine.

--- a/examples/apps/ai_spleen_seg_app/spleen_seg_operator.py
+++ b/examples/apps/ai_spleen_seg_app/spleen_seg_operator.py
@@ -41,7 +41,7 @@ from monai.deploy.operators.monai_seg_inference_operator import MonaiSegInferenc
 
 @input("image", Image, IOType.IN_MEMORY)
 @output("seg_image", Image, IOType.IN_MEMORY)
-@env(pip_packages=["monai==0.6.0", "torch>=1.5", "numpy>=1.17"])
+@env(pip_packages=["monai==0.6.0", "torch>=1.5", "numpy>=1.17", "nibabel"])
 class SpleenSegOperator(Operator):
     """Performs Spleen segmentation with 3D image converted from a DICOM CT series.
 


### PR DESCRIPTION
During testing of the sample app, it was found that nibabel is a runtime dependency used in the Monai SpacingD transform through the use of moani.data.utils.

Added "nibabel" as runtime dependency in the Spleen_seg_operator.py  (no specific version per opetional_import in Monai) 