### PR TITLE
Fix spleen segmentation app

### DIFF
--- a/examples/apps/ai_spleen_seg_app/__main__.py
+++ b/examples/apps/ai_spleen_seg_app/__main__.py
@@ -1,2 +1,4 @@
 from app import AISpleenSegApp
-AISpleenSegApp()
+
+if __name__ == '__main__':
+    AISpleenSegApp(do_run=True)

--- a/monai/deploy/core/application.py
+++ b/monai/deploy/core/application.py
@@ -71,7 +71,8 @@ class Application(ABC):
             runtime_env (Optional[RuntimeEnv]): The runtime environment to use.
             do_run (bool): Whether to run the application.
             path (Optional[Union[str, Path]]): The path to the application (Python file path).
-                This information is used for launching the application to get the package information.
+                This path is used for launching the application to get the package information from
+                `monai.deploy.utils.importutil.get_application` method.
         """
         # Setup app description
         if not self.name:
@@ -93,9 +94,12 @@ class Application(ABC):
             self.path = get_class_file_path(self.__class__)
 
         # Setup program arguments
-        if do_run:
+        if path is None:
             argv = sys.argv
         else:
+            # If `path` is specified, it means that it is called by
+            # monai.deploy.utils.importutil.get_application() to get the package info.
+            # In this case, we should not parse the arguments from the command line.
             argv = [sys.executable, str(self.path)]  # use default parameters
 
         # Parse the command line arguments

--- a/monai/deploy/operators/inference_operator.py
+++ b/monai/deploy/operators/inference_operator.py
@@ -9,8 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import annotations
-
 import functools
 import uuid
 from abc import ABC, abstractmethod
@@ -56,7 +54,7 @@ class InferenceOperator(Operator):
         pass
 
     @abstractmethod
-    def predict(self, data:Any) -> Union(Image, Any):
+    def predict(self, data:Any) -> Union[Image, Any]:
         """Prdicts results using the models(s) with input tensors.
 
         This method must be overridden by a derived class.

--- a/monai/deploy/runner/runner.py
+++ b/monai/deploy/runner/runner.py
@@ -95,7 +95,7 @@ def run_app(map_name: str, input_path: Path, output_path: Path, app_info: dict, 
 
     map_command = app_info["command"]
     # TODO(bhatt-piyush): Fix 'monai-exec' to work correctly.
-    cmd += " -v {}:{} -v {}:{} --entrypoint '/bin/bash' {} -c '{}'".format(
+    cmd += " -v {}:{} -v {}:{} --shm-size=1g --entrypoint '/bin/bash' {} -c '{}'".format(
         input_path.absolute(), map_input, output_path.absolute(), map_output, map_name, map_command
     )
     # cmd += " -v {}:{} -v {}:{} {}".format(


### PR DESCRIPTION
- Fix App launch logic
- Add a workaround fix for #66 
  - Add `--shm-size 1g`
- Fix errors in Python 3.6


https://github.com/Project-MONAI/monai-app-sdk/blob/c91fbd0fb3b8923a1eacd42e4c3e61112e335d18/monai/deploy/core/application.py#L96
```python
        # Setup program arguments
        if do_run:
            argv = sys.argv
        else:
            argv = [sys.executable, str(self.path)]  # use default parameters
```
https://github.com/Project-MONAI/monai-app-sdk/blob/fc045c91cc838f3c7c6109b350f08e52b8236c84/examples/apps/ai_spleen_seg_app/app.py#L71

```python
if __name__ == "__main__":
    # Creates the app and test it standalone.
    # Model file is expected to be at: model/model.ts
    # Input DICOM CT series is expected to be in: input/
    # Output of DICOM Seg instance is to be in: output/
    #
    logging.basicConfig(level=logging.DEBUG)
    app_instance = AISpleenSegApp()  # Optional params' defaults are fine.
    app_instance.run()
```

AiSpleenSegApp(do_run=True) would get the correct input from CLI but AISpleenSegApp().run() does not due to current logic. 

Fix the issue
