### PR TITLE
Fix wrong typings

### DIFF
--- a/examples/apps/ai_spleen_seg_app/app.py
+++ b/examples/apps/ai_spleen_seg_app/app.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 import logging
-from monai.deploy.core import Application, env, resource
+from monai.deploy.core import Application, resource
 from monai.deploy.operators.dicom_data_loader_operator import DICOMDataLoaderOperator
 from monai.deploy.operators.dicom_series_selector_operator import DICOMSeriesSelectorOperator
 from monai.deploy.operators.dicom_series_to_volume_operator import DICOMSeriesToVolumeOperator

--- a/monai/deploy/core/app_context.py
+++ b/monai/deploy/core/app_context.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 from argparse import Namespace
-from typing import Optional, Type
+from typing import Optional
 
 from .resource import Resource
 from .runtime_env import RuntimeEnv
@@ -19,7 +19,7 @@ from .runtime_env import RuntimeEnv
 class AppContext:
     """A class to store the context of an application."""
 
-    def __init__(self, args: Namespace, runtime_env: Optional[Type[RuntimeEnv]] = None):
+    def __init__(self, args: Namespace, runtime_env: Optional[RuntimeEnv] = None):
         # Set the runtime environment
         self.runtime_env = runtime_env or RuntimeEnv()
 

--- a/monai/deploy/core/application.py
+++ b/monai/deploy/core/application.py
@@ -57,7 +57,7 @@ class Application(ABC):
 
     def __init__(
         self,
-        runtime_env: Optional[Type[RuntimeEnv]] = None,
+        runtime_env: Optional[RuntimeEnv] = None,
         do_run: bool = False,
         path: Optional[Union[str, Path]] = None,
     ):

--- a/monai/deploy/core/execution_context.py
+++ b/monai/deploy/core/execution_context.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Optional, Type
+from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from .operator import Operator
@@ -22,7 +22,7 @@ from .models import Model
 class BaseExecutionContext:
     """A base execution context for the application."""
 
-    def __init__(self, datastore: Optional[Datastore] = None, models: Optional[Type[Model]] = None):
+    def __init__(self, datastore: Optional[Datastore] = None, models: Optional[Model] = None):
         if datastore is None:
             self._storage = MemoryDatastore()
         else:

--- a/monai/deploy/core/io_type.py
+++ b/monai/deploy/core/io_type.py
@@ -13,6 +13,7 @@ from enum import Enum
 
 
 class IOType(Enum):
+    UNKNOWN = 0
     DISK = 1
     IN_MEMORY = 2
 

--- a/monai/deploy/core/models/model.py
+++ b/monai/deploy/core/models/model.py
@@ -11,7 +11,7 @@
 
 import os.path
 from pathlib import Path
-from typing import Any, Dict, ItemsView, List, Optional, Tuple, Type
+from typing import Any, Dict, ItemsView, List, Tuple
 
 from monai.deploy.exceptions import ItemNotExistsError, UnknownTypeError
 
@@ -84,7 +84,7 @@ class Model:
         self._predictor = None
 
         # Add self to the list of models
-        self._items: Dict[str, Type[Model]] = {self.name: self}
+        self._items: Dict[str, Model] = {self.name: self}
 
     @property
     def predictor(self):
@@ -193,7 +193,7 @@ class Model:
 
         return model_list
 
-    def items(self) -> ItemsView[str, Type["Model"]]:
+    def items(self) -> ItemsView[str, "Model"]:
         """Return an ItemsView of models that this Model instance has.
 
         If this model represents a model repository, then an ItemsView of submodel objects is returned.

--- a/monai/deploy/core/operator.py
+++ b/monai/deploy/core/operator.py
@@ -11,12 +11,11 @@
 
 import uuid
 from abc import ABC, abstractmethod
-from typing import Type, Union
+from typing import Any, Optional, Type, Union
 
 from monai.deploy.exceptions import UnknownTypeError
 from monai.deploy.utils.importutil import is_subclass
 
-from .domain import Domain
 from .env import BaseEnv
 from .execution_context import ExecutionContext
 from .io_context import InputContext, OutputContext
@@ -75,12 +74,12 @@ class Operator(ABC):
     def __eq__(self, other):
         return self._uid == other._uid
 
-    def add_input(self, label: str, data_type: Type[Domain], storage_type: Union[int, IOType]):
+    def add_input(self, label: str, data_type: Type, storage_type: Union[int, IOType]):
         self._op_info.add_label(IO.INPUT, label)
         self._op_info.set_data_type(IO.INPUT, label, data_type)
         self._op_info.set_storage_type(IO.INPUT, label, storage_type)
 
-    def add_output(self, label: str, data_type: Type[Domain], storage_type: Union[int, IOType]):
+    def add_output(self, label: str, data_type: Type, storage_type: Union[int, IOType]):
         self._op_info.add_label(IO.OUTPUT, label)
         self._op_info.set_data_type(IO.OUTPUT, label, data_type)
         self._op_info.set_storage_type(IO.OUTPUT, label, storage_type)
@@ -164,12 +163,12 @@ class Operator(ABC):
         pass
 
 
-def input(label: str = "", data_type: Type[Domain] = None, storage_type: Union[int, IOType] = None):
+def input(label: str = "", data_type: Type = Any, storage_type: Union[int, IOType] = IOType.UNKNOWN):
     """A decorator that adds input specification to the operator.
 
     Args:
         label (str): A label for the input port.
-        data_type (Type[Domain]): A data type of the input.
+        data_type (Type): A data type of the input.
         storage_type (Union[int, IOType]): A storage type of the input.
 
     Returns:
@@ -195,13 +194,13 @@ def input(label: str = "", data_type: Type[Domain] = None, storage_type: Union[i
     return decorator
 
 
-def output(label: str = "", data_type: Type[Domain] = None, storage_type: Union[int, IOType] = None):
+def output(label: str = "", data_type: Type = Any, storage_type: Union[int, IOType] = IOType.UNKNOWN):
     """A decorator that adds output specification to the operator.
 
     Args:
-        label: A label for the output port.
-        data_type: A data type of the output.
-        storage_type: A storage type of the output.
+        label (str): A label for the output port.
+        data_type (Type): A data type of the output.
+        storage_type (Union[int, IOType]): A storage type of the output.
 
     Returns:
         A decorator that adds output specification to the operator.

--- a/monai/deploy/core/operator_info.py
+++ b/monai/deploy/core/operator_info.py
@@ -10,10 +10,9 @@
 # limitations under the License.
 
 from enum import Enum
-from typing import Type, Union
+from typing import Dict, Set, Type, Union
 
 from .domain.datapath import DataPath
-from .domain.domain import Domain
 from .io_type import IOType
 
 
@@ -30,9 +29,9 @@ class OperatorInfo:
 
     def __init__(self):
         # Initializing the attributes
-        self.labels = {IO.INPUT: set(), IO.OUTPUT: set()}
-        self.data_type = {IO.INPUT: {}, IO.OUTPUT: {}}
-        self.storage_type = {IO.INPUT: {}, IO.OUTPUT: {}}
+        self.labels: Dict[IO, Set] = {IO.INPUT: set(), IO.OUTPUT: set()}
+        self.data_type: Dict[IO, Dict[str, Type]] = {IO.INPUT: {}, IO.OUTPUT: {}}
+        self.storage_type: Dict[IO, Dict[str, IOType]] = {IO.INPUT: {}, IO.OUTPUT: {}}
 
     def ensure_valid(self):
         """Ensure that the operator info is valid.
@@ -53,18 +52,18 @@ class OperatorInfo:
         io_kind = IO(io_kind)
         return self.labels[io_kind]
 
-    def set_data_type(self, io_kind: IO, label: str, data_type: Type[Domain]):
+    def set_data_type(self, io_kind: IO, label: str, data_type: Type):
         io_kind = IO(io_kind)
         self.data_type[io_kind][label] = data_type
 
-    def get_data_type(self, io_kind: IO, label: str) -> Type[Domain]:
+    def get_data_type(self, io_kind: IO, label: str) -> Type:
         io_kind = IO(io_kind)
         return self.data_type[io_kind][label]
 
     def set_storage_type(self, io_kind: IO, label: str, storage_type: Union[int, IOType]):
         io_kind = IO(io_kind)
-        self.storage_type[io_kind][label] = storage_type
+        self.storage_type[io_kind][label] = IOType(storage_type)
 
-    def get_storage_type(self, io_kind: IO, label: str) -> Union[int, IOType]:
+    def get_storage_type(self, io_kind: IO, label: str) -> IOType:
         io_kind = IO(io_kind)
         return self.storage_type[io_kind][label]

--- a/monai/deploy/utils/importutil.py
+++ b/monai/deploy/utils/importutil.py
@@ -15,7 +15,7 @@ import sys
 import warnings
 from importlib import import_module
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Tuple, Type, Union
 
 import pkg_resources
 
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from monai.deploy.core import Application
 
 
-def get_docstring(cls: type) -> str:
+def get_docstring(cls: Type) -> str:
     """Get docstring of a class.
 
     Tries to get docstring from class itself, from its __doc__.
@@ -31,7 +31,7 @@ def get_docstring(cls: type) -> str:
     If __doc__ is not available, it returns empty string.
 
     Args:
-        cls (type): class to get docstring from.
+        cls (Type): class to get docstring from.
 
     Returns:
         A docstring of the class.
@@ -43,11 +43,11 @@ def get_docstring(cls: type) -> str:
     return "\n".join([line.strip() for line in doc.split("\n")])
 
 
-def is_subclass(cls: type, class_or_tuple: Union[str, Tuple[str]]) -> bool:
+def is_subclass(cls: Type, class_or_tuple: Union[str, Tuple[str]]) -> bool:
     """Check if the given type is a subclass of a MONAI App SDK class.
 
     Args:
-        cls (type): A class to check.
+        cls (Type): A class to check.
         class_or_tuple (Union[str, Tuple[str]]): A class name or a tuple of class names.
 
     Returns:


### PR DESCRIPTION
Type[<class name>] was used when it actually refers to
an instance of <class name>.

Fix wrong typings in existing code.

If data_type or storage_type is not specified, its default would be Any and IOType.UNKNOWN, respectively.
