### PR TITLE
Expose input/output path from CLI in compute()

### DIFF
--- a/examples/apps/simple_imaging_app/median_operator.py
+++ b/examples/apps/simple_imaging_app/median_operator.py
@@ -47,6 +47,9 @@ class MedianOperator(MedianOperatorBase):
 
         from skimage.filters import median
 
+        # `context.input.get().path` (Path) is the file/folder path of the input data from the application's context.
+        # `context.output.get().path` (Path) is the file/folder path of the output data from the application's context.
+
         # `context.models.get(model_name)` returns a model instance
         #  (a null model would be returned if model is not available)
         # If model_name is not specified and only one model exists, it returns that model.

--- a/monai/deploy/core/application.py
+++ b/monai/deploy/core/application.py
@@ -65,7 +65,8 @@ class Application(ABC):
 
         It initializes the application's graph, the runtime environment and the application context.
 
-        if `do_run` is True, it would accept user's arguments from CLI and execute the application.
+        if `do_run` is True, it would accept user's arguments from the application's context and
+        execute the application.
 
         Args:
             runtime_env (Optional[RuntimeEnv]): The runtime environment to use.

--- a/monai/deploy/core/domain/__init__.py
+++ b/monai/deploy/core/domain/__init__.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .datapath import DataPath
+from .datapath import DataPath, NamedDataPath
 from .dicom_series import DICOMSeries
 from .dicom_sop_instance import DICOMSOPInstance
 from .dicom_study import DICOMStudy


### PR DESCRIPTION
There is no way to access the first input and the final output path from the intermediate operators.

This patch allow accessing those paths through
ExecutionContext object inside compute() method
of the operator.

- context.input.get() : input path from CLI
- context.output.get() : output path from CLI

NamedDataPath Domain Object is introduced to
provide the same interface with input/output context.
This allows supporting multiple inputs/outputs from CLI
in the future.

Also, DataPath class accepts `read_only` arguments to avoid
overwriting the value.

This closes #81 