### PR TITLE
Use workdir for intermediate disk input and output

### DIFF
--- a/monai/deploy/cli/exec_command.py
+++ b/monai/deploy/cli/exec_command.py
@@ -24,13 +24,17 @@ from monai.deploy.core.graphs.factory import GraphFactory
 def create_exec_parser(subparser: _SubParsersAction, command: str, parents: List[ArgumentParser]) -> ArgumentParser:
     # Intentionally use `argparse.HelpFormatter` instead of `argparse.ArgumentDefaultsHelpFormatter`.
     # Default values for those options are None and those would be filled by `RuntimeEnv` object later.
-    parser = subparser.add_parser(
-        command, formatter_class=argparse.HelpFormatter, parents=parents, add_help=False
-    )
+    parser = subparser.add_parser(command, formatter_class=argparse.HelpFormatter, parents=parents, add_help=False)
 
     parser.add_argument("--input", "-i", help="Path to input folder/file (default: input)")
     parser.add_argument("--output", "-o", help="Path to output folder/file (default: output)")
     parser.add_argument("--model", "-m", help="Path to model(s) folder/file (default: models)")
+    parser.add_argument(
+        "--workdir",
+        "-w",
+        type=str,
+        help="Path to workspace folder (default: A temporary '.monai_workdir' folder in the current folder)",
+    )
     parser.add_argument(
         "--graph",
         help=f"Graph engine (default: {GraphFactory.DEFAULT})",

--- a/monai/deploy/core/app_context.py
+++ b/monai/deploy/core/app_context.py
@@ -27,6 +27,7 @@ class AppContext:
         self.input_path = args.input or self.runtime_env.input
         self.output_path = args.output or self.runtime_env.output
         self.model_path = args.model or self.runtime_env.model
+        self.workdir = args.workdir or self.runtime_env.workdir
 
         # Set the backend engines
         self.graph = args.graph or self.runtime_env.graph

--- a/monai/deploy/core/domain/datapath.py
+++ b/monai/deploy/core/domain/datapath.py
@@ -26,8 +26,8 @@ class DataPath(Domain):
             read_only (bool): True if the the file/directory path cannot be modified.
         """
         super().__init__(metadata=metadata)
-        self._path = Path(path)
-        self._read_only = read_only
+        self._path: Path = Path(path)
+        self._read_only: bool = read_only
 
     @property
     def path(self):
@@ -38,6 +38,11 @@ class DataPath(Domain):
         if self._read_only:
             raise IOMappingError("This DataPath is read-only.")
         self._path = Path(val)
+
+    def to_absolute(self):
+        """Convert the internal representation of the path to an absolute path."""
+        if not self._path.is_absolute():
+            self._path = self._path.absolute()
 
 
 class NamedDataPath(Domain):

--- a/monai/deploy/core/io_context.py
+++ b/monai/deploy/core/io_context.py
@@ -14,8 +14,13 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from .execution_context import ExecutionContext
+    from .operator import Operator
+    from .datastores.datastore import Datastore
+    from .operator_info import OperatorInfo
 
 from monai.deploy.exceptions import IOMappingError, ItemAlreadyExistsError, ItemNotExistsError
+
+from .domain.datapath import DataPath
 
 
 class IOContext(ABC):
@@ -25,11 +30,11 @@ class IOContext(ABC):
 
     def __init__(self, execution_context: "ExecutionContext"):
         """Constructor for IOContext."""
-        self._execution_context = execution_context
-        self._op = execution_context.op
-        self._op_info = self._op.op_info
-        self._labels = self._op_info.get_labels(self._io_kind)
-        self._storage = execution_context.storage
+        self._execution_context: "ExecutionContext" = execution_context
+        self._op: Operator = execution_context.op
+        self._op_info: OperatorInfo = self._op.op_info
+        self._labels: str = self._op_info.get_labels(self._io_kind)
+        self._storage: Datastore = execution_context.storage
 
     def get_default_label(self, label: str = "") -> str:
         """Get a default label for IO context."""
@@ -46,6 +51,9 @@ class IOContext(ABC):
     def get_group_path(self, postfix: str = "") -> str:
         """Returns the path for the group.
 
+        The group path returned would be:
+            "/operators/{self._op.uid}/{execution_index}/{postfix}"
+
         Args:
             postfix: The postfix for the path.
 
@@ -56,52 +64,47 @@ class IOContext(ABC):
         path = f"/operators/{self._op.uid}/{execution_index}/{postfix}"
         return path
 
+    def get(self, label: str = "") -> Any:
+        """Returns the data for the operator.
+
+        It uses a sub path ({self._io_kind}/{label}) to get the data.
+        The final group path (key) would be:
+            "/operators/{self._op.uid}/{execution_index}/{self._io_kind}/{label}"
+        """
+        label = self.get_default_label(label)
+        key = self.get_group_path(f"{self._io_kind}/{label}")
+        storage = self._storage
+        if not storage.exists(key):
+            raise ItemNotExistsError(f"'{key}' does not exist.")
+        return storage.get(key)
+
+    def set(self, value: Any, label: str = ""):
+        """Sets the data for the operator.
+
+        It uses a sub path ({self._io_kind}/{label}) to set the data.
+        The final group path (key) would be:
+            "/operators/{self._op.uid}/{execution_index}/{self._io_kind}/{label}"
+        """
+        label = self.get_default_label(label)
+        key = self.get_group_path(f"{self._io_kind}/{label}")
+        storage = self._storage
+        if storage.exists(key):
+            raise ItemAlreadyExistsError(f"{key} already exists.")
+        else:
+            # Convert to the absolute path if 'value' is an instance of DataPath and it is a relative path.
+            # This is to keep the actual path of the data in the storage across different Operator execution contexts.
+            if isinstance(value, DataPath):
+                value.to_absolute()
+            storage.put(key, value)
+
 
 class InputContext(IOContext):
     """An input context for an operator."""
 
     _io_kind = "input"
 
-    def get(self, label: str = "") -> Any:
-        """Returns the input data for the operator."""
-        label = self.get_default_label(label)
-        key = self.get_group_path(f"input/{label}")
-        storage = self._storage
-        if not storage.exists(key):
-            raise ItemNotExistsError(f"'{key}' does not exist.")
-        return storage.get(key)
-
-    def set(self, value: Any, label: str = ""):
-        """Sets the input data for the operator."""
-        label = self.get_default_label(label)
-        key = self.get_group_path(f"input/{label}")
-        storage = self._storage
-        if storage.exists(key):
-            raise ItemAlreadyExistsError(f"{key} already exists.")
-        else:
-            storage.put(key, value)
-
 
 class OutputContext(IOContext):
     """An output context for an operator."""
 
     _io_kind = "output"
-
-    def get(self, label: str = "") -> Any:
-        """Returns the output data for the operator."""
-        label = self.get_default_label(label)
-        key = self.get_group_path(f"output/{label}")
-        storage = self._storage
-        if not storage.exists(key):
-            raise ItemNotExistsError(f"'{key}' does not exist.")
-        return storage.get(key)
-
-    def set(self, value: Any, label: str = ""):
-        """Sets the output data for the operator."""
-        label = self.get_default_label(label)
-        key = self.get_group_path(f"output/{label}")
-        storage = self._storage
-        if storage.exists(key):
-            raise ItemAlreadyExistsError(f"{key} already exists.")
-        else:
-            storage.put(key, value)

--- a/monai/deploy/core/runtime_env.py
+++ b/monai/deploy/core/runtime_env.py
@@ -29,14 +29,16 @@ class RuntimeEnv(ABC):
         "input": ("MONAI_INPUTPATH", "input"),
         "output": ("MONAI_OUTPUTPATH", "output"),
         "model": ("MONAI_MODELPATH", "models"),
-        "graph": ("MONAI_GRAPH", GraphFactory.DEFAULT),
-        "datastore": ("MONAI_DATASTORE", DatastoreFactory.DEFAULT),
-        "executor": ("MONAI_EXECUTOR", ExecutorFactory.DEFAULT),
+        "workdir": ("MONAI_WORKDIR", ""),
+        "graph": ("MONAI_GRAPH", GraphFactory.DEFAULT),  # The 'MONAI_GRAPH' is not part of MAP spec.
+        "datastore": ("MONAI_DATASTORE", DatastoreFactory.DEFAULT),  # The 'MONAI_DATASTORE' is not part of MAP spec.
+        "executor": ("MONAI_EXECUTOR", ExecutorFactory.DEFAULT),  # The 'MONAI_EXECUTOR' is not part of MAP spec.
     }
 
     input: str = ""
     output: str = ""
     model: str = ""
+    workdir: str = ""
 
     def __init__(self, defaults: Dict[str, Tuple[str]] = None):
         if defaults is None:

--- a/monai/deploy/packager/constants.py
+++ b/monai/deploy/packager/constants.py
@@ -17,7 +17,7 @@ class DefaultValues:
     # TODO(KavinKrishnan): Decide a default image to use.
     # BASE_IMAGE = "nvcr.io/nvidia/cuda:11.1-runtime-ubuntu20.04"
     BASE_IMAGE = "nvcr.io/nvidia/pytorch:21.07-py3"
-    WORK_DIR = "/opt/monai/app"
+    WORK_DIR = "/var/monai"
     INPUT_DIR = "input"
     OUTPUT_DIR = "output"
     MODELS_DIR = "/opt/monai/models"

--- a/monai/deploy/packager/templates.py
+++ b/monai/deploy/packager/templates.py
@@ -54,6 +54,9 @@ COMMON_FOOTPRINT = """
     # Create bytecodes for monai and app's code. This would help speed up loading time a little bit.
     RUN python -m compileall -q -j 0 /home/monai/.local/lib/python3.8/site-packages/monai /opt/monai/app
 
+    # Set the working directory
+    WORKDIR {working_dir}
+
     ENTRYPOINT [ "/opt/monai/executor/monai-exec" ]
 """
 
@@ -72,6 +75,7 @@ UBUNTU_DOCKERFILE_TEMPLATE = (
     ENV TERM=xterm-256color
     ENV MONAI_INPUTPATH={full_input_path}
     ENV MONAI_OUTPUTPATH={full_output_path}
+    ENV MONAI_WORKDIR={working_dir}
     ENV MONAI_APPLICATION={app_dir}
     ENV MONAI_TIMEOUT={timeout}
 
@@ -108,6 +112,7 @@ PYTORCH_DOCKERFILE_TEMPLATE = (
     ENV TERM=xterm-256color
     ENV MONAI_INPUTPATH={full_input_path}
     ENV MONAI_OUTPUTPATH={full_output_path}
+    ENV MONAI_WORKDIR={working_dir}
     ENV MONAI_APPLICATION={app_dir}
     ENV MONAI_TIMEOUT={timeout}
 
@@ -206,7 +211,7 @@ DOCKERIGNORE_TEMPLATE = """
 TEMPLATE_MAP = {
     "ubuntu": UBUNTU_DOCKERFILE_TEMPLATE,
     "pytorch": PYTORCH_DOCKERFILE_TEMPLATE,
-    '.dockerignore' : DOCKERIGNORE_TEMPLATE
+    ".dockerignore": DOCKERIGNORE_TEMPLATE,
 }
 
 


### PR DESCRIPTION
- Add `--workdir` to specify working directory in `monai-deploy exec`
  - If not specified, it would use A temporary '.monai_workdir' folder in
    the current folder
- Refactor InputContext and OutputContext
  - Move common methods (get/set) to the parent class (IOContext)
- In the IOContext, always set the absolute path if the value is
  the instance of DataPath.
  - Convert to the absolute path if 'value' is an instance of DataPath
     and it is a relative path.
  - This is to keep the actual path of the data in the storage across different
     Operator execution contexts.
- When an operator is executed, change current folder (pwd) to the output
   folder of the operator.
   - Restore the current folder and remove the temporary working folder
     at the end of the executor
- Fix incorrect default working directory in the app.json
- Set the working directory when building the image

Here, it doesn't create the temporary folder for `workdir` at `/tmp` with `tempfile.TemporaryDirectory()` method which creates an arbitrary folder and always removes it at the end of the execution. By having a temporary workdir with a static name(`.monai_workdir`), it would help to debug (If an exception is raised during the execution, the user can check local temporary workdir).

With this patch, now we can specify like this if the operator is not a leaf operator:

```python
@input("image", Image, IOType.IN_MEMORY)
@output("image", DataPath, IOType.DISK)
class IntermediateOperator(Operator):
    def compute(self, input: InputContext, output: OutputContext, context: ExecutionContext):
        from skimage.filters import gaussian
        from skimage.io import imsave

        data_in = input.get("image").asnumpy()
        data_out = gaussian(data_in, sigma=0.2)

        output_filename = "output.png"
        imsave(output_filename, data_out)

        output.set(DataPath(output_filename))
```

In the next operator, `input.get("image").path` would be the absolute path of the file "output.png".
(Something like `/var/monai/operators/af7b2fa0-4f95-4fd9-b225-2c4de28602a9/0/output/output.png` where `af7b2fa0-4f95-4fd9-b225-2c4de28602a9` is a UUID of the IntermediateOperator instance ).



resolves #60 
