### PR TITLE
MAR: create output folder if folder does not exist

### DIFF
--- a/monai/deploy/runner/run_command.py
+++ b/monai/deploy/runner/run_command.py
@@ -28,7 +28,9 @@ def create_run_parser(subparser: _SubParsersAction, command: str, parents: List[
 
     parser.add_argument("input", metavar="<input>", type=argparse_types.valid_existing_path, help="Input data path")
 
-    parser.add_argument("output", metavar="<output>", type=argparse_types.valid_path, help="Output data directory path")
+    parser.add_argument(
+        "output", metavar="<output>", type=argparse_types.valid_dir_path, help="Output data directory path"
+    )
 
     parser.add_argument(
         "-q",

--- a/monai/deploy/utils/argparse_types.py
+++ b/monai/deploy/utils/argparse_types.py
@@ -19,6 +19,33 @@ logger = logging.getLogger(__name__)
 def valid_dir_path(path: str) -> Path:
     """Helper type checking and type converting method for ArgumentParser.add_argument
     to convert string input to pathlib.Path if the given path exists and it is a directory path.
+    If directory does not exist, create the directory and convert string input to pathlib.Path.
+
+    Args:
+        path: string input path
+
+    Returns:
+        If path exists and is a directory, return absolute path as a pathlib.Path object.
+
+        If path exists and is not a directory, raises argparse.ArgumentTypeError.
+
+        If path doesn't exist, create the directory and return absolute path as a pathlib.Path object.
+    """
+    dir_path = Path(path).absolute()
+    if dir_path.exists():
+        if dir_path.is_dir():
+            return dir_path
+        else:
+            raise argparse.ArgumentTypeError(f"Expected directory path: '{dir_path}' is not a directory")
+
+    # create directory
+    dir_path.mkdir(parents=True)
+    return dir_path
+
+
+def valid_existing_dir_path(path: str) -> Path:
+    """Helper type checking and type converting method for ArgumentParser.add_argument
+    to convert string input to pathlib.Path if the given path exists and it is a directory path.
 
     Args:
         path: string input path
@@ -28,9 +55,9 @@ def valid_dir_path(path: str) -> Path:
 
         If path doesn't exist or it is not a directory, raises argparse.ArgumentTypeError.
     """
-    dir_path = Path(path)
+    dir_path = Path(path).absolute()
     if dir_path.exists() and dir_path.is_dir():
-        return dir_path.absolute()
+        return dir_path
     raise argparse.ArgumentTypeError(f"No such directory: '{dir_path}'")
 
 
@@ -46,21 +73,8 @@ def valid_existing_path(path: str) -> Path:
 
         If path doesn't exist, raises argparse.ArgumentTypeError.
     """
-    file_path = Path(path)
+    file_path = Path(path).absolute()
     if file_path.exists():
-        return file_path.absolute()
+        return file_path
     raise argparse.ArgumentTypeError(f"No such file/folder: '{file_path}'")
 
-
-def valid_path(path: str) -> Path:
-    """Helper type checking and type converting method for ArgumentParser.add_argument
-    to convert string input to pathlib.Path.
-
-    Args:
-        path: string input path
-
-    Returns:
-        Return absolute path as a pathlib.Path object.
-    """
-    dir_path = Path(path)
-    return dir_path

--- a/tests/fixtures/runner_fixtures.py
+++ b/tests/fixtures/runner_fixtures.py
@@ -15,9 +15,10 @@ import shutil
 import pytest
 
 
-@pytest.fixture(scope="session")
-def mock_manifest_export_dir(tmp_path_factory, faux_app_manifest, faux_pkg_manifest):
-    dataset_path = tmp_path_factory.mktemp("manifest_export_dir")
+@pytest.fixture(scope="function")
+def mock_manifest_export_dir(tmp_path, faux_app_manifest, faux_pkg_manifest):
+    dataset_path = tmp_path / "manifest_export_dir"
+    dataset_path.mkdir()
     with open((dataset_path / "app.json"), "w") as f:
         json.dump(faux_app_manifest, f)
     with open((dataset_path / "pkg.json"), "w") as f:
@@ -124,31 +125,39 @@ def faux_app_manifest_with_absolute_path():
     yield app_manifest
 
 
-@pytest.fixture(scope="session")
-def faux_input_file(tmp_path_factory):
-    input_dir = tmp_path_factory.mktemp("input")
+@pytest.fixture(scope="function")
+def faux_file(tmp_path):
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
     input_file = input_dir / "input.jpg"
     input_file.touch()
     yield input_file
 
 
-@pytest.fixture(scope="session")
-def faux_input_folder(tmp_path_factory):
-    input_dir = tmp_path_factory.mktemp("input")
-    input_folder = input_dir
-    yield input_folder
+@pytest.fixture(scope="function")
+def faux_folder(tmp_path):
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    yield input_dir
 
 
-@pytest.fixture(scope="session")
-def faux_input_file_with_space(tmp_path_factory):
-    input_dir = tmp_path_factory.mktemp("input with space")
+@pytest.fixture(scope="function")
+def faux_file_with_space(tmp_path):
+    input_dir = tmp_path / "input with space"
+    input_dir.mkdir()
     input_file = input_dir / "input with space.jpg"
     input_file.touch()
     yield input_file
 
 
-@pytest.fixture(scope="session")
-def faux_input_folder_with_space(tmp_path_factory):
-    input_dir = tmp_path_factory.mktemp("input with space")
-    input_folder = input_dir
-    yield input_folder
+@pytest.fixture(scope="function")
+def faux_folder_with_space(tmp_path):
+    input_dir = tmp_path / "input with space"
+    input_dir.mkdir()
+    yield input_dir
+
+
+@pytest.fixture(scope="function")
+def non_existent_file_path(tmp_path):
+    some_faux_path = tmp_path / "some" / "non" / "existent" / "path"
+    yield some_faux_path

--- a/tests/unit/test_argparse_types.py
+++ b/tests/unit/test_argparse_types.py
@@ -1,0 +1,130 @@
+# Copyright 2021 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from contextlib import contextmanager
+from os import path
+from unittest.mock import patch
+from pathlib import Path, PosixPath
+
+import pytest
+import getpass
+from pytest_lazyfixture import lazy_fixture
+
+from argparse import ArgumentTypeError
+
+
+@pytest.mark.parametrize("expected_dir_path", [lazy_fixture("tmp_path"), lazy_fixture("non_existent_file_path")])
+def test_valid_dir_path_valid_args(expected_dir_path):
+    from monai.deploy.utils.argparse_types import valid_dir_path
+
+    actual_dir_path = valid_dir_path(str(expected_dir_path))
+
+    assert type(actual_dir_path) == PosixPath
+    assert actual_dir_path == expected_dir_path
+    assert expected_dir_path.exists() == True
+    assert actual_dir_path.is_dir() == True
+    assert actual_dir_path.is_absolute() == True
+    assert actual_dir_path.owner() == getpass.getuser()
+
+
+@pytest.mark.parametrize("expected_dir_path", [lazy_fixture("tmp_path"), lazy_fixture("non_existent_file_path")])
+def test_valid_dir_path_valid_relative_path(expected_dir_path):
+    from monai.deploy.utils.argparse_types import valid_dir_path
+
+    @contextmanager
+    def working_directory(path):
+        import os
+
+        prev_cwd = Path.cwd()
+        os.chdir(path)
+        try:
+            yield
+        finally:
+            os.chdir(prev_cwd)
+
+    root_dir = expected_dir_path.root
+    with working_directory(root_dir) as _:
+        relative_dir_path = expected_dir_path.relative_to(root_dir)
+        actual_dir_path = valid_dir_path(str(relative_dir_path))
+
+        assert type(actual_dir_path) == PosixPath
+        assert actual_dir_path == expected_dir_path
+        assert expected_dir_path.exists() == True
+        assert actual_dir_path.is_dir() == True
+        assert actual_dir_path.is_absolute() == True
+        assert actual_dir_path.owner() == getpass.getuser()
+
+
+def test_valid_dir_path_invalid_args(faux_file):
+    from monai.deploy.utils.argparse_types import valid_dir_path
+
+    expected_invalid_dir_path = faux_file
+    assert expected_invalid_dir_path.exists() == True
+    assert expected_invalid_dir_path.is_dir() == False
+
+    with pytest.raises(ArgumentTypeError) as wrapped_error:
+        valid_dir_path(str(expected_invalid_dir_path))
+    assert wrapped_error.type == ArgumentTypeError
+
+    assert expected_invalid_dir_path.exists() == True
+    assert expected_invalid_dir_path.is_dir() == False
+
+
+def test_valid_existing_dir_path_valid_args(tmp_path):
+    from monai.deploy.utils.argparse_types import valid_existing_dir_path
+
+    expected_dir_path = tmp_path
+    assert expected_dir_path.exists() == True
+    assert expected_dir_path.is_dir() == True
+    actual_dir_path = valid_existing_dir_path(str(expected_dir_path))
+
+    assert type(actual_dir_path) == PosixPath
+    assert actual_dir_path == expected_dir_path
+    assert expected_dir_path.exists() == True
+    assert actual_dir_path.is_dir() == True
+    assert actual_dir_path.owner() == getpass.getuser()
+
+
+@pytest.mark.parametrize("input_path", [lazy_fixture("non_existent_file_path"), lazy_fixture("faux_file")])
+def test_valid_existing_dir_path_invalid_args(input_path):
+    from monai.deploy.utils.argparse_types import valid_existing_dir_path
+
+    assert input_path.is_dir() == False
+    with pytest.raises(ArgumentTypeError) as wrapped_error:
+        valid_existing_dir_path(str(input_path))
+    assert wrapped_error.type == ArgumentTypeError
+
+    assert input_path.is_dir() == False
+
+
+@pytest.mark.parametrize("expected_input_path", [lazy_fixture("faux_file"), lazy_fixture("faux_folder")])
+def test_valid_existing_path_valid_args(expected_input_path):
+    from monai.deploy.utils.argparse_types import valid_existing_path
+
+    assert expected_input_path.exists() == True
+    actual_input_path = valid_existing_path(str(expected_input_path))
+
+    assert type(actual_input_path) == PosixPath
+    assert actual_input_path == expected_input_path
+    assert actual_input_path.exists()
+
+
+@pytest.mark.parametrize("input_path", [lazy_fixture("non_existent_file_path")])
+def test_valid_existing_path_valid_args(input_path):
+    from monai.deploy.utils.argparse_types import valid_existing_path
+
+    assert input_path.exists() == False
+    with pytest.raises(ArgumentTypeError) as wrapped_error:
+        valid_existing_path(str(input_path))
+    assert wrapped_error.type == ArgumentTypeError
+
+    assert input_path.exists() == False
+

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -63,12 +63,12 @@ def test_fetch_map_manifest(
 @pytest.mark.parametrize(
     "return_value, input_path, output_path, quiet",
     [
-        # (0, lazy_fixture("faux_input_file"), Path("output/"), False),
-        (0, lazy_fixture("faux_input_folder"), Path("output/"), False),
-        (0, lazy_fixture("faux_input_file"), Path("output/"), True),
-        (0, lazy_fixture("faux_input_folder"), Path("output/"), True),
-        (125, lazy_fixture("faux_input_file"), Path("output/"), False),
-        (125, lazy_fixture("faux_input_folder"), Path("output/"), False),
+        (0, lazy_fixture("faux_file"), Path("output/"), False),
+        (0, lazy_fixture("faux_folder"), Path("output/"), False),
+        (0, lazy_fixture("faux_file"), Path("output/"), True),
+        (0, lazy_fixture("faux_folder"), Path("output/"), True),
+        (125, lazy_fixture("faux_file"), Path("output/"), False),
+        (125, lazy_fixture("faux_folder"), Path("output/"), False),
     ],
 )
 @patch("monai.deploy.runner.runner.run_cmd")
@@ -100,12 +100,12 @@ def test_run_app(mock_run_cmd, return_value, input_path, output_path, quiet, sam
 @pytest.mark.parametrize(
     "return_value, input_path, output_path, quiet",
     [
-        (0, lazy_fixture("faux_input_file_with_space"), Path("output with space/"), False),
-        (0, lazy_fixture("faux_input_folder_with_space"), Path("output with space/"), False),
-        (0, lazy_fixture("faux_input_file_with_space"), Path("output with space/"), True),
-        (0, lazy_fixture("faux_input_folder_with_space"), Path("output with space/"), True),
-        (125, lazy_fixture("faux_input_file_with_space"), Path("output with space/"), False),
-        (125, lazy_fixture("faux_input_folder_with_space"), Path("output with space/"), False),
+        (0, lazy_fixture("faux_file_with_space"), Path("output with space/"), False),
+        (0, lazy_fixture("faux_folder_with_space"), Path("output with space/"), False),
+        (0, lazy_fixture("faux_file_with_space"), Path("output with space/"), True),
+        (0, lazy_fixture("faux_folder_with_space"), Path("output with space/"), True),
+        (125, lazy_fixture("faux_file_with_space"), Path("output with space/"), False),
+        (125, lazy_fixture("faux_folder_with_space"), Path("output with space/"), False),
     ],
 )
 @patch("monai.deploy.runner.runner.run_cmd")
@@ -141,12 +141,12 @@ def test_run_app_for_input_output_path_with_space(
 @pytest.mark.parametrize(
     "return_value, input_path, output_path, quiet",
     [
-        (0, lazy_fixture("faux_input_file"), Path("output/"), False),
-        (0, lazy_fixture("faux_input_folder"), Path("output/"), False),
-        (0, lazy_fixture("faux_input_file"), Path("output/"), True),
-        (0, lazy_fixture("faux_input_folder"), Path("output/"), True),
-        (125, lazy_fixture("faux_input_file"), Path("output/"), False),
-        (125, lazy_fixture("faux_input_folder"), Path("output/"), False),
+        (0, lazy_fixture("faux_file"), Path("output/"), False),
+        (0, lazy_fixture("faux_folder"), Path("output/"), False),
+        (0, lazy_fixture("faux_file"), Path("output/"), True),
+        (0, lazy_fixture("faux_folder"), Path("output/"), True),
+        (125, lazy_fixture("faux_file"), Path("output/"), False),
+        (125, lazy_fixture("faux_folder"), Path("output/"), False),
     ],
 )
 @patch("monai.deploy.runner.runner.run_cmd")


### PR DESCRIPTION
closes #67 

Output folder:
- Simply use the given path if the folder exists.
- If the folder doesn't exist, create the folder with the current user as owner and mount it.

**Changes:**
- [x] Create a folder if it doesn't exist
- [x] Add more unit tests
- [x] Renaming fixtures for more generic usage