### PR TITLE
Rename Python package to monai-deploy-app-sdk

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -236,4 +236,4 @@ For string definition, [f-string](https://www.python.org/dev/peps/pep-0498/) is 
 ### Release a new version
 
 [github ci]: https://github.com/Project-MONAI/monai-deploy-app-sdk/actions
-[monai-app-sdk issue list]: https://github.com/Project-MONAI/monai-deploy-app-sdk/issues
+[monai-deploy-app-sdk issue list]: https://github.com/Project-MONAI/monai-deploy-app-sdk/issues

--- a/README.md
+++ b/README.md
@@ -20,18 +20,18 @@ MONAI Deploy Application SDK offers a framework and associated tools to design, 
 
 ## Installation
 
-To install [the current release](https://pypi.org/project/monai-app-sdk/), you can simply run:
+To install [the current release](https://pypi.org/project/monai-deploy-app-sdk/), you can simply run:
 
 ```bash
-pip install monai-app-sdk  # NOTE: monai-app-sdk package is not available in PyPI for now.
+pip install monai-deploy-app-sdk  # NOTE: monai-deploy-app-sdk package is not available in PyPI for now.
 ```
 
 ## Getting Started
 
 ```bash
-pip install monai-app-sdk  # NOTE: monai-app-sdk package is not available in PyPI for now.
+pip install monai-deploy-app-sdk  # NOTE: monai-deploy-app-sdk package is not available in PyPI for now.
 
-# Clone monai-app-sdk repository for accessing examples.
+# Clone monai-deploy-app-sdk repository for accessing examples.
 git clone https://github.com/Project-MONAI/monai-deploy-app-sdk.git
 cd monai-deploy-app-sdk
 
@@ -79,5 +79,5 @@ Join the conversation on Twitter [@ProjectMONAI](https://twitter.com/ProjectMONA
 - Issue tracker: <https://github.com/Project-MONAI/monai-deploy-app-sdk/issues>
 - Wiki: <https://github.com/Project-MONAI/monai-deploy-app-sdk/wiki>
 - Test status: <https://github.com/Project-MONAI/monai-deploy-app-sdk/actions>
-- PyPI package: <https://pypi.org/project/monai-app-sdk>
-<!-- - Docker Hub: <https://hub.docker.com/r/projectmonai/monai-app-sdk> -->
+- PyPI package: <https://pypi.org/project/monai-deploy-app-sdk>
+<!-- - Docker Hub: <https://hub.docker.com/r/projectmonai/monai-deploy-app-sdk> -->

--- a/monai-deploy-app-sdk.code-workspace
+++ b/monai-deploy-app-sdk.code-workspace
@@ -31,9 +31,9 @@
 				"name": "Python: simple_imaging_app",
 				"type": "python",
 				"request": "launch",
-				"program": "${workspaceFolder:monai-app-sdk}/examples/apps/simple_imaging_app/app.py",
-				"args": ["-i", "${workspaceFolder:monai-app-sdk}/examples/apps/simple_imaging_app/brain_mr_input.jpg", "-o", "${workspaceFolder:monai-app-sdk}/output"],
-				"cwd": "${workspaceFolder:monai-app-sdk}",
+				"program": "${workspaceFolder:monai-deploy-app-sdk}/examples/apps/simple_imaging_app/app.py",
+				"args": ["-i", "${workspaceFolder:monai-deploy-app-sdk}/examples/apps/simple_imaging_app/brain_mr_input.jpg", "-o", "${workspaceFolder:monai-deploy-app-sdk}/output"],
+				"cwd": "${workspaceFolder:monai-deploy-app-sdk}",
 				"console": "integratedTerminal",
 				// Hanging on WSL2 if DISPLAY is set. Due to https://github.com/matplotlib/matplotlib/pull/17396
 				"env" : {"DISPLAY": ""}

--- a/monai/deploy/operators/dicom_seg_writer_operator.py
+++ b/monai/deploy/operators/dicom_seg_writer_operator.py
@@ -626,8 +626,8 @@ def segslice_from_mhd(dcm_output, seg_img, input_ds, num_labels):
 
 
 def test():
-    data_path = "/home/mqin/src/monai-app-sdk/examples/apps/ai_spleen_seg_app/input"
-    out_path = "/home/mqin/src/monai-app-sdk/examples/apps/ai_spleen_seg_app/output/dcm_seg_test.dcm"
+    data_path = "/home/mqin/src/monai-deploy-app-sdk/examples/apps/ai_spleen_seg_app/input"
+    out_path = "/home/mqin/src/monai-deploy-app-sdk/examples/apps/ai_spleen_seg_app/output/dcm_seg_test.dcm"
 
     files = []
     loader = DICOMDataLoaderOperator()

--- a/monai/deploy/packager/templates.py
+++ b/monai/deploy/packager/templates.py
@@ -43,8 +43,8 @@ COMMON_FOOTPRINT = """
 
     RUN pip install --no-cache-dir --upgrade -r {map_requirements_path}
 
-    # Override monai-app-sdk module
-    COPY --chown=monai:monai ./monai-app-sdk /home/monai/.local/lib/python3.8/site-packages/monai/deploy/
+    # Override monai-deploy-app-sdk module
+    COPY --chown=monai:monai ./monai-deploy-app-sdk /home/monai/.local/lib/python3.8/site-packages/monai/deploy/
 
     COPY --chown=monai:monai ./map/app.json /etc/monai/
     COPY --chown=monai:monai ./map/pkg.json /etc/monai/

--- a/monai/deploy/packager/util.py
+++ b/monai/deploy/packager/util.py
@@ -96,9 +96,9 @@ def build_image(args: dict, temp_dir: str):
     else:
         shutil.copytree(application_path, target_application_path)
 
-    # Copy monai-app-sdk module to temp directory (under 'monai-app-sdk' folder)
-    monai_app_sdk_path = os.path.join(dist_module_path("monai-app-sdk"), "monai", "deploy")
-    target_monai_app_sdk_path = os.path.join(temp_dir, "monai-app-sdk")
+    # Copy monai-deploy-app-sdk module to temp directory (under 'monai-deploy-app-sdk' folder)
+    monai_app_sdk_path = os.path.join(dist_module_path("monai-deploy-app-sdk"), "monai", "deploy")
+    target_monai_app_sdk_path = os.path.join(temp_dir, "monai-deploy-app-sdk")
     shutil.copytree(monai_app_sdk_path, target_monai_app_sdk_path)
 
     # Parse SDK provided values
@@ -108,7 +108,7 @@ def build_image(args: dict, temp_dir: str):
     pip_packages = args["application_info"]["pip-packages"]
 
     # Append required packages for SDK to pip_packages
-    monai_app_sdk_requires = dist_requires("monai-app-sdk")
+    monai_app_sdk_requires = dist_requires("monai-deploy-app-sdk")
     pip_packages.extend(monai_app_sdk_requires)
 
     pip_folder = os.path.join(temp_dir, "pip")

--- a/run
+++ b/run
@@ -325,13 +325,13 @@ install_python_dev_deps() {
 
 install_edit_mode() {
     # Create a symlink to the virtual environment.
-    # This solves an issue with separate package folders for 'monai' and 'monai-app-sdk' like below:
+    # This solves an issue with separate package folders for 'monai' and 'monai-deploy-app-sdk' like below:
     # - 'monai': installed with 'pip install monai'
-    # - 'monai-app-sdk': installed with 'pip install -e .  # installed with development(edit) mode
+    # - 'monai-deploy-app-sdk': installed with 'pip install -e .  # installed with development(edit) mode
     local monai_package_path=$(${MONAI_PY_EXE} $TOP/monai/deploy/utils/importutil.py dist_module_path monai)
-    local sdk_package_path=$(${MONAI_PY_EXE} $TOP/monai/deploy/utils/importutil.py dist_module_path monai-app-sdk)
+    local sdk_package_path=$(${MONAI_PY_EXE} $TOP/monai/deploy/utils/importutil.py dist_module_path monai-deploy-app-sdk)
     local is_sdk_editable="false"
-    if ${MONAI_PY_EXE} $TOP/monai/deploy/utils/importutil.py is_dist_editable monai-app-sdk; then
+    if ${MONAI_PY_EXE} $TOP/monai/deploy/utils/importutil.py is_dist_editable monai-deploy-app-sdk; then
         is_sdk_editable="true"
     fi
 
@@ -340,24 +340,24 @@ install_edit_mode() {
     c_echo b "is_sdk_editable   : " Z "${is_sdk_editable}"
 
     if [ "${is_sdk_editable}" == "false" ]; then
-        c_echo W "Installing monai-app-sdk in edit mode..."
+        c_echo W "Installing monai-deploy-app-sdk in edit mode..."
         if [ -n "${VIRTUAL_ENV}" ] || [ -n "${CONDA_PREFIX}" ]; then
             run_command ${MONAI_PY_EXE} -m pip install -e .
         else
-            c_echo_err R "You must be in a virtual environment to install monai-app-sdk in edit mode."
+            c_echo_err R "You must be in a virtual environment to install monai-deploy-app-sdk in edit mode."
         fi
 
-        if ${MONAI_PY_EXE} $TOP/monai/deploy/utils/importutil.py is_dist_editable monai-app-sdk; then
+        if ${MONAI_PY_EXE} $TOP/monai/deploy/utils/importutil.py is_dist_editable monai-deploy-app-sdk; then
             is_sdk_editable="true"
         fi
 
-        sdk_package_path=$(${MONAI_PY_EXE} $TOP/monai/deploy/utils/importutil.py dist_module_path monai-app-sdk)
+        sdk_package_path=$(${MONAI_PY_EXE} $TOP/monai/deploy/utils/importutil.py dist_module_path monai-deploy-app-sdk)
         c_echo b "sdk_package_path  : " Z "${sdk_package_path}"
         c_echo b "is_sdk_editable   : " Z "${is_sdk_editable}"
     fi
 
     if [ "${is_sdk_editable}" = "false" ]; then
-        c_echo W "Installing monai-app-sdk in edit mode..."
+        c_echo W "Installing monai-deploy-app-sdk in edit mode..."
     fi
 
     if [ "$is_sdk_editable" = "true" ] && [ -n "${monai_package_path}" ] && [ ! -L ${monai_package_path}/monai/deploy ]; then
@@ -376,7 +376,7 @@ setup() {
     install_python_dev_deps
 }
 
-clean_desc() { c_echo 'Clean up temporary files and uninstall monai-app-sdk
+clean_desc() { c_echo 'Clean up temporary files and uninstall monai-deploy-app-sdk
 '
 }
 clean() {
@@ -742,9 +742,9 @@ It executes the following command:
 
   ' "${MONAI_PY_EXE}"' -m py.test --cache-clear -vv \
       --cov=monai \
-      --junitxml="'"$TOP/junit-monai-app-sdk.xml"'" \
+      --junitxml="'"$TOP/junit-monai-deploy-app-sdk.xml"'" \
       --cov-config="'"$TOP/.coveragerc"'" \
-      --cov-report=xml:"'"$TOP/monai-app-sdk-coverage.xml"'" \
+      --cov-report=xml:"'"$TOP/monai-deploy-app-sdk-coverage.xml"'" \
       --cov-report term \
       "$@"
 
@@ -761,9 +761,9 @@ pytest() {
     pushd $TOP > /dev/null
     run_command ${MONAI_PY_EXE} -m py.test --cache-clear -vv \
         --cov=monai \
-        --junitxml="$TOP/junit-monai-app-sdk.xml" \
+        --junitxml="$TOP/junit-monai-deploy-app-sdk.xml" \
         --cov-config="$TOP/.coveragerc" \
-        --cov-report=xml:"$TOP/monai-app-sdk-coverage.xml" \
+        --cov-report=xml:"$TOP/monai-deploy-app-sdk-coverage.xml" \
         --cov-report term \
         "$@"
     result=$?

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-name = monai-app-sdk
+name = monai-deploy-app-sdk
 author = MONAI Consortium
 author_email = monai.contact@gmail.com
 url = https://monai.io/


### PR DESCRIPTION
We would like to rename PyPI package name from `monai-app-sdk` (#12) to `monai-deploy-app-sdk` to be consistent with the repository name and to avoid confusion from the user side.

PyPI package would be created for this new name.
