### PR TITLE
Add requirements.txt handling, utilize spinner class, and base image verification

### DIFF
--- a/monai/deploy/packager/constants.py
+++ b/monai/deploy/packager/constants.py
@@ -16,13 +16,11 @@ class DefaultValues:
     """
 
     DOCKER_FILE_NAME = "dockerfile"
-    # TODO(KavinKrishnan): Decide a default image to use.
-    # BASE_IMAGE = "nvcr.io/nvidia/cuda:11.1-runtime-ubuntu20.04"
     BASE_IMAGE = "nvcr.io/nvidia/pytorch:21.07-py3"
-    WORK_DIR = "/var/monai"
+    DOCKERFILE_TYPE = "pytorch"
+    WORK_DIR = "/var/monai/"
     INPUT_DIR = "input"
     OUTPUT_DIR = "output"
     MODELS_DIR = "/opt/monai/models"
     API_VERSION = "0.1.0"
-    VERSION = "0.0.0"
     TIMEOUT = 0

--- a/monai/deploy/packager/package_command.py
+++ b/monai/deploy/packager/package_command.py
@@ -23,14 +23,21 @@ def create_package_parser(subparser: _SubParsersAction, command: str, parents: L
 
     parser.add_argument("application", type=str, help="MONAI application path")
     parser.add_argument("--tag", "-t", required=True, type=str, help="MONAI application package tag")
-    parser.add_argument("--base", type=str, help="Base Application Image")
-    parser.add_argument("--working-dir", "-w", type=str, help="Directory mounted in container for Application")
+    parser.add_argument("--base", "-b", type=str, help="Base Application Image")
     parser.add_argument("--input-dir", "-i", type=str, help="Directory mounted in container for Application Input")
-    parser.add_argument("--output-dir", "-o", type=str, help="Directory mounted in container for Application Output")
     parser.add_argument("--models-dir", type=str, help="Directory mounted in container for Models Path")
     parser.add_argument("--model", "-m", type=str, help="Optional Path to directory containing all application models")
-    parser.add_argument("--version", type=str, help="Version of the Application")
+    parser.add_argument("--no-cache", "-n", action="store_true", help="Packager will not use cache when building image")
+    parser.add_argument("--output-dir", "-o", type=str, help="Directory mounted in container for Application Output")
+    parser.add_argument("--working-dir", "-w", type=str, help="Directory mounted in container for Application")
+    parser.add_argument(
+        "--requirements",
+        "-r",
+        type=str,
+        help="Optional Path to requirements.txt containing package dependencies of application",
+    )
     parser.add_argument("--timeout", type=str, help="Timeout")
+    parser.add_argument("--version", type=str, help="Version of the Application")
 
     return parser
 

--- a/monai/deploy/utils/argparse_types.py
+++ b/monai/deploy/utils/argparse_types.py
@@ -77,4 +77,3 @@ def valid_existing_path(path: str) -> Path:
     if file_path.exists():
         return file_path
     raise argparse.ArgumentTypeError(f"No such file/folder: '{file_path}'")
-

--- a/monai/deploy/utils/spinner.py
+++ b/monai/deploy/utils/spinner.py
@@ -20,7 +20,7 @@ class ProgressSpinner:
     """
 
     def __init__(self, message, delay=0.2):
-        self.spinner_symbols = itertools.cycle(["-", "/", "|", "\\"])
+        self.spinner_symbols = itertools.cycle(["-", "\\", "|", "/"])
         self.delay = delay
         self.stop_event = Event()
         self.spinner_visible = False
@@ -69,6 +69,8 @@ class ProgressSpinner:
         """
         Stop spinner process.
         """
+        sys.stdout.write("\b")
+        sys.stdout.write("Done")
         if sys.stdout.isatty():
             self.stop_event.set()
             self._remove_spinner(cleanup=True)


### PR DESCRIPTION
Adding:

-  requirements.txt handling: users can provide a path to the requirements.txt file, overriding values provided by sdk
-  packager no longer uses it own spinner function, and utilizes the SDK spinner class in /util
-  added verification of user provided base images such that they are either  `nvcr.io/nvidia/cuda` or `nvcr.io/nvidia/pytorch` images
- additionally, added a `--no-cache` flag to CLI so user has the option to build docker images not using cache