### PR TITLE
Verify operator IO data types with typeguard

### DIFF
--- a/monai/deploy/core/io_context.py
+++ b/monai/deploy/core/io_context.py
@@ -12,6 +12,8 @@
 from abc import ABC
 from typing import TYPE_CHECKING, Any, Set
 
+from typeguard import check_type
+
 # To avoid "Cannot resolve forward reference" error
 # : https://github.com/agronholm/sphinx-autodoc-typehints#dealing-with-circular-imports
 from . import execution_context
@@ -101,6 +103,19 @@ class IOContext(ABC):
             # This is to keep the actual path of the data in the storage across different Operator execution contexts.
             if isinstance(value, DataPath):
                 value.to_absolute()
+
+            # Verify the type of the value is matching the type of the input/output of the operator.
+            # Use 'typeguard' package because Python's built-in isinstance() does not support parameterized generic type
+            # checking: https://www.python.org/dev/peps/pep-0585/#id15
+            data_type = self._op_info.get_data_type(self._io_kind, label)
+            try:
+                check_type("value", value, data_type)
+            except TypeError:
+                raise IOMappingError(
+                    f"The data type of '{label}' in the {self._io_kind} of '{self._op}' is {data_type}, but the value"
+                    f" to set is the data type of {type(value)}."
+                )
+
             storage.put(key, value)
 
 

--- a/monai/deploy/operators/dicom_data_loader_operator.py
+++ b/monai/deploy/operators/dicom_data_loader_operator.py
@@ -34,7 +34,7 @@ generate_uid, _ = optional_import("pydicom.uid", name="generate_uid")
 
 
 @input("dicom_files", DataPath, IOType.DISK)
-@output("dicom_study_list", DICOMStudy, IOType.IN_MEMORY)
+@output("dicom_study_list", List[DICOMStudy], IOType.IN_MEMORY)
 @env(pip_packages=["pydicom >= 1.4.2"])
 class DICOMDataLoaderOperator(Operator):
     """

--- a/monai/deploy/operators/dicom_series_selector_operator.py
+++ b/monai/deploy/operators/dicom_series_selector_operator.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict
+from typing import Dict, List
 
 from monai.deploy.core import ExecutionContext, InputContext, IOType, Operator, OutputContext, input, output
 from monai.deploy.core.domain.dicom_series import DICOMSeries
@@ -18,7 +18,7 @@ from monai.deploy.exceptions import ItemNotExistsError
 from monai.deploy.operators.dicom_data_loader_operator import DICOMDataLoaderOperator
 
 
-@input("dicom_study_list", DICOMStudy, IOType.IN_MEMORY)
+@input("dicom_study_list", List[DICOMStudy], IOType.IN_MEMORY)
 @input("selection_rules", Dict, IOType.IN_MEMORY)
 @output("dicom_series", DICOMSeries, IOType.IN_MEMORY)
 class DICOMSeriesSelectorOperator(Operator):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy>=1.17
 networkx>=2.4
 colorama>=0.4.1
+typeguard>=2.12.1


### PR DESCRIPTION
- Verify the data type of Operator input/output by using [typeguard](.
- Fix existing IO type errors in `DICOMDataLoaderOperator` and `DICOMSeriesSelectorOperator`\

Resolves #59 

The cyclic graph seems to be handled by default when using NetworkX (but may need to check explicitly in the future).

```~/miniconda3/envs/monai/lib/python3.6/site-packages/monai/deploy/core/executors/single_process_executor.py in run(self)
     79             # Set source input for a label if op is a root node and (<data type>, <storage type>) == (DataPath, IOType.DISK)
     80             is_root = g.is_root(op)
---> 81             if is_root:
     82                 input_op_info = op.op_info
     83                 input_labels = input_op_info.get_labels(IO.INPUT)

~/miniconda3/envs/monai/lib/python3.6/site-packages/networkx/algorithms/dag.py in topological_sort(G)
    195     if indegree_map:
    196         raise nx.NetworkXUnfeasible(
--> 197             "Graph contains a cycle or graph changed " "during iteration"
    198         )
    199 

NetworkXUnfeasible: Graph contains a cycle or graph changed during iteration
```