### PR TITLE
Update README.md for MONAI Deploy site

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,14 @@ We encourage you to create pull requests early. It helps us track the contributi
 
 Please note that, as per PyTorch, MONAI Deploy App SDK uses American English spelling. This means classes and variables should be: normali**z**e, visuali**z**e, colo~~u~~r, etc.
 
+For local development, please execute the following command:
+
+```bash
+./run setup
+```
+
+This will set up the development environment, installing necessary packages.
+
 ### Preparing pull requests
 
 To ensure the code quality, MONAI Deploy App SDK relies on several linting tools ([flake8 and its plugins](https://gitlab.com/pycqa/flake8), [black](https://github.com/psf/black), [isort](https://github.com/timothycrosley/isort)),

--- a/README.md
+++ b/README.md
@@ -56,14 +56,6 @@ Technical documentation is available at [docs.monai.io](https://docs.monai.io).
 
 ## Contributing
 
-For local development, please execute the following command:
-
-```bash
-./run setup
-```
-
-This will set up the development environment, installing necessary packages.
-
 For guidance on making a contribution to MONAI Deploy App SDK, see the [contributing guidelines](https://github.com/Project-MONAI/monai-deploy-app-sdk/blob/main/CONTRIBUTING.md).
 
 ## Community


### PR DESCRIPTION
- Update feature section in README.md
- Add a header for MONAI Deploy site.
- Move setup command to CONTRIBUTING.md

Closes #125 
