### PR TITLE
Setup ReadTheDocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,28 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/source/conf.py
+
+# Build documentation with MkDocs
+#mkdocs:
+#  configuration: mkdocs.yml
+
+# Optionally build your docs in additional formats such as PDF and ePub
+# formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.6
+  install:
+    - requirements: docs/requirements.txt
+#  system_packages: true
+
+
+build:
+  image: stable

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -11,7 +11,7 @@ linkify-it-py==1.0.1  # https://myst-parser.readthedocs.io/en/latest/syntax/opti
 sphinx-togglebutton==0.2.3
 sphinx-copybutton==0.4.0
 sphinxcontrib-bibtex<2.0.0  # https://github.com/executablebooks/jupyter-book/issues/1137
-sphinxcontrib-spelling  # https://sphinxcontrib-spelling.readthedocs.io/en/latest/index.html
+sphinxcontrib-spelling==7.2.1  # https://sphinxcontrib-spelling.readthedocs.io/en/latest/index.html
 sphinx-thebe==0.0.10
 sphinx-panels==0.6.0
 ablog==0.10.19
@@ -23,11 +23,12 @@ scikit-image
 plotly
 nibabel
 monai
+pydicom
 sphinx-autodoc-typehints==1.12.0
-sphinxcontrib-applehelp
-sphinxcontrib-devhelp
-sphinxcontrib-htmlhelp
-sphinxcontrib-jsmath
-sphinxcontrib-qthelp
-sphinxcontrib-serializinghtml
-sphinxcontrib-mermaid
+sphinxcontrib-applehelp==1.0.2
+sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-htmlhelp==2.0.0
+sphinxcontrib-jsmath==1.0.1
+sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-serializinghtml==1.1.5
+sphinxcontrib-mermaid==0.7.1

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -4,13 +4,33 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+# -- Handle ReadTheDocs.org build -------------------------------------------
+import os
+
+# on_rtd is whether we are on readthedocs.org
+on_rtd = os.environ.get("READTHEDOCS", None) == "True"
+if on_rtd:
+    READTHEDOCS_PROJECT = os.environ.get("READTHEDOCS_PROJECT", "monai-deploy-app-sdk")
+    READTHEDOCS_VERSION = os.environ.get("READTHEDOCS_VERSION", "latest")
+    import subprocess
+
+    subprocess.call(
+        "/bin/bash -c 'source /home/docs/checkouts/readthedocs.org/user_builds/"
+        f"{READTHEDOCS_PROJECT}/envs/{READTHEDOCS_VERSION}/bin/activate; ../../run setup'",
+        shell=True,
+    )
+    subprocess.call(
+        "/bin/bash -c 'source /home/docs/checkouts/readthedocs.org/user_builds/"
+        f"{READTHEDOCS_PROJECT}/envs/{READTHEDOCS_VERSION}/bin/activate; ../../run setup_gen_docs'",
+        shell=True,
+    )
+
 # -- Path setup --------------------------------------------------------------
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import os
 import re
 import sys
 

--- a/notebooks/tutorials/02_mednist_app.ipynb
+++ b/notebooks/tutorials/02_mednist_app.ipynb
@@ -135,7 +135,7 @@
     "### Download dataset\n",
     "\n",
     "The MedNIST dataset was gathered from several sets from [TCIA](https://wiki.cancerimagingarchive.net/display/Public/Data+Usage+Policies+and+Restrictions),\n",
-    "[the RSNA Bone Age Challenge](http://rsnachallenges.cloudapp.net/competitions/4),\n",
+    "the RSNA Bone Age Challenge(https://www.rsna.org/education/ai-resources-and-training/ai-image-challenge/rsna-pediatric-bone-age-challenge-2017),\n",
     "and [the NIH Chest X-ray dataset](https://cloud.google.com/healthcare/docs/resources/public-datasets/nih-chest).\n",
     "\n",
     "The dataset is kindly made available by [Dr. Bradley J. Erickson M.D., Ph.D.](https://www.mayo.edu/research/labs/radiology-informatics/overview) (Department of Radiology, Mayo Clinic)\n",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,9 +15,9 @@ pytype>=2020.6.1; platform_system != "Windows"
 types-pkg_resources
 mypy>=0.790
 psutil
-Sphinx==3.5.3
+Sphinx==4.1.2
 recommonmark==0.6.0
-sphinx-autodoc-typehints==1.11.1
+sphinx-autodoc-typehints==1.12.0
 sphinx-rtd-theme==0.5.2
 pytest==6.2.4
 pytest-cov==2.12.1

--- a/run
+++ b/run
@@ -342,7 +342,7 @@ install_edit_mode() {
     if [ "${is_sdk_editable}" == "false" ]; then
         c_echo W "Installing monai-deploy-app-sdk in edit mode..."
         if [ -n "${VIRTUAL_ENV}" ] || [ -n "${CONDA_PREFIX}" ]; then
-            run_command ${MONAI_PY_EXE} -m pip install -e .
+            run_command ${MONAI_PY_EXE} -m pip install -e ${TOP}
         else
             c_echo_err R "You must be in a virtual environment to install monai-deploy-app-sdk in edit mode."
         fi
@@ -910,6 +910,17 @@ install_doc_requirements() {
     fi
 }
 
+setup_gen_docs() {
+    local output_folder=${1:-${TOP}/dist/docs}
+
+    # Remove existing files in dist/docs
+    run_command rm -rf ${output_folder}/*
+
+    # Symbolic link notebooks folder from 'docs/source/notebooks' to 'notebooks'
+    run_command rm -rf ${TOP}/docs/source/notebooks
+    run_command ln -sfn ${TOP}/notebooks ${TOP}/docs/source/notebooks
+}
+
 gen_docs_desc() { c_echo 'Generate documents
 
 Generated docs would be avaialable at ${TOP}/dist/docs.
@@ -931,12 +942,7 @@ gen_docs() {
     # Install prerequisites
     install_doc_requirements
 
-    # Remove existing files in dist/docs
-    run_command rm -rf ${output_folder}/*
-
-    # Symbolic link notebooks folder from 'docs/source/notebooks' to 'notebooks'
-    run_command rm -rf ${TOP}/docs/source/notebooks
-    run_command ln -sfn ${TOP}/notebooks ${TOP}/docs/source/notebooks
+    setup_gen_docs ${output_folder}
 
     c_echo W "Sphinx build html..."
     sphinx-build -E -b html $TOP/docs/source ${output_folder}
@@ -1002,12 +1008,7 @@ gen_docs_dev() {
     # Install prerequisites
     install_doc_requirements
 
-    # Remove existing files in dist/docs
-    run_command rm -rf ${output_folder}/*
-
-    # Symbolic link notebooks folder from 'docs/source/notebooks' to 'notebooks'
-    run_command rm -rf ${TOP}/docs/source/notebooks
-    run_command ln -sfn ${TOP}/notebooks ${TOP}/docs/source/notebooks
+    setup_gen_docs ${output_folder}
 
     c_echo W "Sphinx build html..."
     sphinx-build -E -b html $TOP/docs/source ${output_folder}


### PR DESCRIPTION
- Fix `run` script to use absolute path for `pip install -e`
- Add pre-install statements for readthedocs build
- Add `.readthedocs.yaml`
- Use hard-coded sphinx-related versions in docs/requirements.txt

Signed-off-by: Gigon Bae <gbae@nvidia.com>