### PR TITLE
Segmentation mask image should have uint8 type, for both the saved nii.gz file and in memory Image 

### DIFF
--- a/examples/apps/ai_spleen_seg_app/spleen_seg_operator.py
+++ b/examples/apps/ai_spleen_seg_app/spleen_seg_operator.py
@@ -27,6 +27,7 @@ from monai.transforms import (
     Spacingd,
     ToTensord,
 )
+from numpy import uint8
 
 
 @input("image", Image, IOType.IN_MEMORY)
@@ -109,6 +110,6 @@ class SpleenSegOperator(Operator):
                 Invertd(
                     keys=pred_key, transform=pre_transforms, orig_keys=self._input_dataset_key, nearest_interp=True
                 ),
-                SaveImaged(keys=pred_key, output_dir=out_dir, output_postfix="seg", resample=False),
+                SaveImaged(keys=pred_key, output_dir=out_dir, output_postfix="seg", output_dtype=uint8, resample=False),
             ]
         )

--- a/examples/apps/ai_spleen_seg_app/spleen_seg_operator.py
+++ b/examples/apps/ai_spleen_seg_app/spleen_seg_operator.py
@@ -12,6 +12,8 @@
 import logging
 from os import path
 
+from numpy import uint8
+
 from monai.deploy.core import ExecutionContext, Image, InputContext, IOType, Operator, OutputContext, env, input, output
 from monai.deploy.operators.monai_seg_inference_operator import InMemImageReader, MonaiSegInferenceOperator
 from monai.transforms import (
@@ -27,7 +29,6 @@ from monai.transforms import (
     Spacingd,
     ToTensord,
 )
-from numpy import uint8
 
 
 @input("image", Image, IOType.IN_MEMORY)

--- a/examples/apps/ai_unetr_seg_app/unetr_seg_operator.py
+++ b/examples/apps/ai_unetr_seg_app/unetr_seg_operator.py
@@ -12,6 +12,8 @@
 import logging
 from os import path
 
+from numpy import uint8
+
 from monai.deploy.core import ExecutionContext, Image, InputContext, IOType, Operator, OutputContext, env, input, output
 from monai.deploy.operators.monai_seg_inference_operator import InMemImageReader, MonaiSegInferenceOperator
 from monai.transforms import (
@@ -28,7 +30,7 @@ from monai.transforms import (
     Spacingd,
     ToTensord,
 )
-from numpy import uint8
+
 
 @input("image", Image, IOType.IN_MEMORY)
 @output("seg_image", Image, IOType.IN_MEMORY)

--- a/examples/apps/ai_unetr_seg_app/unetr_seg_operator.py
+++ b/examples/apps/ai_unetr_seg_app/unetr_seg_operator.py
@@ -28,7 +28,7 @@ from monai.transforms import (
     Spacingd,
     ToTensord,
 )
-
+from numpy import uint8
 
 @input("image", Image, IOType.IN_MEMORY)
 @output("seg_image", Image, IOType.IN_MEMORY)
@@ -111,6 +111,6 @@ class UnetrSegOperator(Operator):
                 Invertd(
                     keys=pred_key, transform=pre_transforms, orig_keys=self._input_dataset_key, nearest_interp=True
                 ),
-                SaveImaged(keys=pred_key, output_dir=out_dir, output_postfix="seg", resample=False),
+                SaveImaged(keys=pred_key, output_dir=out_dir, output_postfix="seg", output_dtype=uint8, resample=False),
             ]
         )

--- a/monai/deploy/operators/dicom_seg_writer_operator.py
+++ b/monai/deploy/operators/dicom_seg_writer_operator.py
@@ -521,7 +521,7 @@ def set_pixel_meta(dicomOutput, input_ds):
 
     dicomOutput.Rows = input_ds.Rows
     dicomOutput.Columns = input_ds.Columns
-    dicomOutput.BitsAllocated = 1  # add_new(0x00280100, 'US', 8) # Bits allocated
+    dicomOutput.BitsAllocated = 8  # add_new(0x00280100, 'US', 8) # Bits allocated
     dicomOutput.BitsStored = 1
     dicomOutput.HighBit = 0
     dicomOutput.PixelRepresentation = 0
@@ -576,7 +576,7 @@ def segslice_from_mhd(dcm_output, seg_img, input_ds, num_labels):
             frame_meta = create_frame_meta(input_ds[img_slice], label, referenceInstances, dimIdxVal, img_slice)
 
             out_frames.append(frame_meta)
-            logging.info(
+            logging.debug(
                 "img slice {}, label {}, frame {}, img pos {}".format(
                     img_slice, label, out_frame_counter, safe_get(input_ds[img_slice], 0x00200032)
                 )

--- a/monai/deploy/operators/monai_seg_inference_operator.py
+++ b/monai/deploy/operators/monai_seg_inference_operator.py
@@ -192,7 +192,7 @@ class MonaiSegInferenceOperator(InferenceOperator):
                     #       the resultant ndarray for each slice needs to be transposed back, and the depth
                     #       dim moved back to first, otherwise the seg ndarray would be flipped compared to
                     #       the DICOM pixel array, causing the DICOM Seg Writer generate flipped seg images.
-                    out_ndarray = np.swapaxes(out_ndarray, 2, 0)
+                    out_ndarray = np.swapaxes(out_ndarray, 2, 0).astype(np.uint8)
                     print(f"Output Seg image numpy array shaped: {out_ndarray.shape}")
                     print(f"Output Seg image pixel max value: {np.amax(out_ndarray)}")
                     out_image = Image(out_ndarray)


### PR DESCRIPTION
It is known that the MONAI transform class, `SaveImaged`, uses `np.float32` as the output image data type if none specified.

For segmentation image, the mask image invariantly has `uint8 `for each segment. Furthermore, it has become known that external render programs, e.g. Clara Render Server, assumes `uint8 `segmentation mask image and would fail with other data type.

In addition, the App SDK DICOM Segmentation Writer consumes the in memory segmentation image, and even though `float32` type is handled, it is better to save the image with uint8 for reducing mem usage as well as being consistent. 
  