### PR TITLE
Fix pydicom dependency

### DIFF
--- a/monai/deploy/core/domain/dicom_sop_instance.py
+++ b/monai/deploy/core/domain/dicom_sop_instance.py
@@ -15,15 +15,15 @@ from monai.deploy.utils.importutil import optional_import
 
 from .domain import Domain
 
-DataElement_, _ = optional_import("pydicom", name="DataElement")
+DataElement_, dataelement_ok_ = optional_import("pydicom", name="DataElement")
 # Dynamic class is not handled so make it Any for now: https://github.com/python/mypy/issues/2477
-DataElement: Any = DataElement_
-Dataset_, _ = optional_import("pydicom", name="Dataset")
+DataElement: Any = DataElement_ if dataelement_ok_ else Any
+Dataset_, dataset_ok_ = optional_import("pydicom", name="Dataset")
 # Dynamic class is not handled so make it Any for now: https://github.com/python/mypy/issues/2477
-Dataset: Any = Dataset_
-TagType_, _ = optional_import("pydicom.tag", name="TagType")
+Dataset: Any = Dataset_ if dataset_ok_ else Any
+TagType_, tagtype_ok_ = optional_import("pydicom.tag", name="TagType")
 # Dynamic class is not handled so make it Any for now: https://github.com/python/mypy/issues/2477
-TagType: Any = TagType_
+TagType: Any = TagType_ if tagtype_ok_ else Any
 
 
 class DICOMSOPInstance(Domain):


### PR DESCRIPTION
Fix dicom dependency by setting the types to Any if pydicom is not available.

Without this patch, it causes the following error when monai-deploy-app-sdk v0.1.0rc1 is installed.

```
---------------------------------------------------------------------------
OptionalImportError                       Traceback (most recent call last)
<ipython-input-1-159a1f2129f7> in <module>()
----> 1 import monai.deploy.core as md
      2 from monai.deploy.core import (
      3     Application,
      4     DataPath,
      5     ExecutionContext,

/home/gbae/miniconda3/envs/mednist/lib/python3.6/site-packages/monai/__init__.py in <module>()
     41 
     42 # load directory modules only, skip loading individual files
---> 43 load_submodules(sys.modules[__name__], False, exclude_pattern=excludes)
     44 
     45 # load all modules, this will trigger all export decorations

/home/gbae/miniconda3/envs/mednist/lib/python3.6/site-packages/monai/utils/module.py in load_submodules(basemod, load_all, exclude_pattern)
     71         if (is_pkg or load_all) and name not in sys.modules and match(exclude_pattern, name) is None:
     72             try:
---> 73                 mod = import_module(name)
     74                 importer.find_module(name).load_module(name)  # type: ignore
     75                 submodules.append(mod)

/home/gbae/miniconda3/envs/mednist/lib/python3.6/importlib/__init__.py in import_module(name, package)
    124                 break
    125             level += 1
--> 126     return _bootstrap._gcd_import(name[level:], package, level)
    127 
    128 

/home/gbae/miniconda3/envs/mednist/lib/python3.6/site-packages/monai/deploy/__init__.py in <module>()
     21 """
     22 
---> 23 from . import _version, cli, core, exceptions, packager, runner, utils
     24 
     25 __version__ = _version.get_versions()["version"]

/home/gbae/miniconda3/envs/mednist/lib/python3.6/site-packages/monai/deploy/core/__init__.py in <module>()
     25 """
     26 
---> 27 from .application import Application
     28 from .domain.datapath import DataPath
     29 from .domain.image import Image

/home/gbae/miniconda3/envs/mednist/lib/python3.6/site-packages/monai/deploy/core/application.py in <module>()
     16 
     17 from monai.deploy.cli.main import LOG_CONFIG_FILENAME, parse_args, set_up_logging
---> 18 from monai.deploy.core.graphs.factory import GraphFactory
     19 from monai.deploy.core.models import ModelFactory
     20 from monai.deploy.exceptions import IOMappingError

/home/gbae/miniconda3/envs/mednist/lib/python3.6/site-packages/monai/deploy/core/graphs/__init__.py in <module>()
     18 """
     19 
---> 20 from .factory import GraphFactory
     21 from .graph import Graph
     22 from .nx_digraph import NetworkXGraph

/home/gbae/miniconda3/envs/mednist/lib/python3.6/site-packages/monai/deploy/core/graphs/factory.py in <module>()
     14 from monai.deploy.exceptions import UnknownTypeError
     15 
---> 16 from .graph import Graph
     17 from .nx_digraph import NetworkXGraph
     18 

/home/gbae/miniconda3/envs/mednist/lib/python3.6/site-packages/monai/deploy/core/graphs/graph.py in <module>()
     13 from typing import Dict, Generator, Optional, Set
     14 
---> 15 from monai.deploy.core.operator import Operator
     16 
     17 

/home/gbae/miniconda3/envs/mednist/lib/python3.6/site-packages/monai/deploy/core/operator.py in <module>()
     18 
     19 from .env import BaseEnv
---> 20 from .execution_context import ExecutionContext
     21 from .io_context import InputContext, OutputContext
     22 from .io_type import IOType

/home/gbae/miniconda3/envs/mednist/lib/python3.6/site-packages/monai/deploy/core/execution_context.py in <module>()
     12 from typing import Optional
     13 
---> 14 from monai.deploy.core.domain.datapath import NamedDataPath
     15 
     16 # To avoid "Cannot resolve forward reference" error

/home/gbae/miniconda3/envs/mednist/lib/python3.6/site-packages/monai/deploy/core/domain/__init__.py in <module>()
     23 
     24 from .datapath import DataPath, NamedDataPath
---> 25 from .dicom_series import DICOMSeries
     26 from .dicom_sop_instance import DICOMSOPInstance
     27 from .dicom_study import DICOMStudy

/home/gbae/miniconda3/envs/mednist/lib/python3.6/site-packages/monai/deploy/core/domain/dicom_series.py in <module>()
     10 # limitations under the License.
     11 
---> 12 from .dicom_sop_instance import DICOMSOPInstance
     13 from .domain import Domain
     14 

/home/gbae/miniconda3/envs/mednist/lib/python3.6/site-packages/monai/deploy/core/domain/dicom_sop_instance.py in <module>()
     27 
     28 
---> 29 class DICOMSOPInstance(Domain):
     30     """This class representes a SOP Instance.
     31 

/home/gbae/miniconda3/envs/mednist/lib/python3.6/site-packages/monai/deploy/core/domain/dicom_sop_instance.py in DICOMSOPInstance()
     40         return self._sop
     41 
---> 42     def __getitem__(self, key: Union[int, slice, TagType]) -> Union[Dataset, DataElement]:
     43         return self._sop.__getitem__(key)
     44 

/home/gbae/miniconda3/envs/mednist/lib/python3.6/typing.py in inner(*args, **kwds)
    677     def inner(*args, **kwds):
    678         try:
--> 679             return cached(*args, **kwds)
    680         except TypeError:
    681             pass  # All real errors (not unhashable args) are raised below.

/home/gbae/miniconda3/envs/mednist/lib/python3.6/typing.py in __getitem__(self, parameters)
    801         if self is not Union:
    802             _check_generic(self, parameters)
--> 803         return self.__class__(parameters, origin=self, _root=True)
    804 
    805     def _subs_tree(self, tvars=None, args=None):

/home/gbae/miniconda3/envs/mednist/lib/python3.6/typing.py in __new__(cls, parameters, origin, _root, *args)
    750         # Pre-calculate the __hash__ on instantiation.
    751         # This improves speed for complex substitutions.
--> 752         subs_tree = self._subs_tree()
    753         if isinstance(subs_tree, tuple):
    754             self.__tree_hash__ = hash(frozenset(subs_tree))

/home/gbae/miniconda3/envs/mednist/lib/python3.6/typing.py in _subs_tree(self, tvars, args)
    806         if self is Union:
    807             return Union  # Nothing to substitute
--> 808         tree_args = _subs_tree(self, tvars, args)
    809         tree_args = _remove_dups_flatten(tree_args)
    810         if len(tree_args) == 1:

/home/gbae/miniconda3/envs/mednist/lib/python3.6/typing.py in _subs_tree(cls, tvars, args)
    601     tree_args = []
    602     for arg in cls.__args__:
--> 603         tree_args.append(_replace_arg(arg, tvars, args))
    604     # ... then continue replacing down the origin chain.
    605     for ocls in orig_chain:

/home/gbae/miniconda3/envs/mednist/lib/python3.6/typing.py in _replace_arg(arg, tvars, args)
    559     if tvars is None:
    560         tvars = []
--> 561     if hasattr(arg, '_subs_tree') and isinstance(arg, (GenericMeta, _TypingBase)):
    562         return arg._subs_tree(tvars, args)
    563     if isinstance(arg, TypeVar):

/home/gbae/miniconda3/envs/mednist/lib/python3.6/site-packages/monai/deploy/utils/importutil.py in __getattr__(self, name)
    256                 OptionalImportError: When you call this method.
    257             """
--> 258             raise self._exception
    259 
    260         def __call__(self, *_args, **_kwargs):

/home/gbae/miniconda3/envs/mednist/lib/python3.6/site-packages/monai/deploy/utils/importutil.py in optional_import(module, version, version_checker, name, descriptor, version_args, allow_namespace_pkg)
    215         actual_cmd = f"import {module}"
    216     try:
--> 217         pkg = __import__(module)  # top level module
    218         the_module = import_module(module)
    219         if not allow_namespace_pkg:

OptionalImportError: from pydicom.tag import TagType (No module named 'pydicom').

For details about installing the optional dependencies, please visit:
    https://docs.monai.io/en/latest/installation.html#installing-the-recommended-dependencies
```
Signed-off-by: Gigon Bae <gbae@nvidia.com>