### PR TITLE
Derived app class needs to support args and kwargs in the run function.

### DIFF
--- a/examples/apps/ai_spleen_seg_app/app.py
+++ b/examples/apps/ai_spleen_seg_app/app.py
@@ -29,10 +29,10 @@ class AISpleenSegApp(Application):
         self._logger = logging.getLogger("{}.{}".format(__name__, type(self).__name__))
         super().__init__(*args, **kwargs)
 
-    def run(self):
+    def run(self, *args, **kwargs):
         # This method calls the base class to run. Can be omitted if simply calling through.
         self._logger.debug(f"Begin {self.run.__name__}")
-        super().run()
+        super().run(*args, **kwargs)
         self._logger.debug(f"End {self.run.__name__}")
 
     def compose(self):

--- a/examples/apps/ai_unetr_seg_app/app.py
+++ b/examples/apps/ai_unetr_seg_app/app.py
@@ -30,10 +30,10 @@ class AIUnetrSegApp(Application):
         self._logger = logging.getLogger("{}.{}".format(__name__, type(self).__name__))
         super().__init__(*args, **kwargs)
 
-    def run(self):
+    def run(self, *args, **kwargs):
         # This method calls the base class to run. Can be omitted if simply calling through.
         self._logger.debug(f"Begin {self.run.__name__}")
-        super().run()
+        super().run(*args, **kwargs)
         self._logger.debug(f"End {self.run.__name__}")
 
     def compose(self):


### PR DESCRIPTION
It is an oversight that in the derived Application classes, the run() method shadows the base run, and as such, does not support args.

It is also true that the run() function in the derived class does not add any logic except logging statements, though keeping it in the derived class is fine too.