### PR TITLE
Use POSIX path for App Runner to handle Windows path

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 0.1.1rc1
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<release>a|b|rc)(?P<build>\d+))?
 serialize = 
 	{major}.{minor}.{patch}{release}{build}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.1rc1
+current_version = 0.1.1rc2
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<release>a|b|rc)(?P<build>\d+))?
 serialize = 
 	{major}.{minor}.{patch}{release}{build}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -7,14 +7,16 @@ serialize =
 tag_name = {new_version}
 tag_message = Bump version: {current_version} → {new_version}
 commit = True
+commit_args = -s
 tag = True
 
 [bumpversion:part:release]
 values = 
-	''
 	a
 	b
 	rc
+	''
+optional_value = ''
 
 [bumpversion:part:build]
 first_value = 1

--- a/docs/source/getting_started/installing_app_sdk.md
+++ b/docs/source/getting_started/installing_app_sdk.md
@@ -15,7 +15,7 @@ pip install --upgrade monai-deploy-app-sdk
 ```
 
 :::{note}
-For packaging your application, [MONAI Application Packager](/developing_with_sdk/packaging_app) and [MONAI Application Runner (MAR)](/developing_with_sdk/executing_packaged_app_locally) requires NVIDIA Docker installed:
+For packaging your application, [MONAI Application Packager](/developing_with_sdk/packaging_app) and [MONAI Application Runner (MAR)](/developing_with_sdk/executing_packaged_app_locally) requires NVIDIA Docker (NVIDIA Container Toolkit) installed:
 
 <https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker>
 
@@ -27,4 +27,8 @@ The image size is large so please pull the image in advance to save time.
 docker pull nvcr.io/nvidia/pytorch:21.07-py3
 ```
 
+:::
+
+:::{note}
+Windows users can install [CUDA on WSL](https://docs.nvidia.com/cuda/wsl-user-guide/index.html) to use MONAI Deploy App SDK.
 :::

--- a/monai/deploy/runner/runner.py
+++ b/monai/deploy/runner/runner.py
@@ -12,6 +12,7 @@
 import argparse
 import json
 import logging
+import posixpath
 import shutil
 import sys
 import tempfile
@@ -85,13 +86,14 @@ def run_app(map_name: str, input_path: Path, output_path: Path, app_info: dict, 
     if not quiet:
         cmd += " -a STDOUT"
 
-    map_input = Path(app_info["input"]["path"])
-    map_output = Path(app_info["output"]["path"])
-    if not map_input.is_absolute():
-        map_input = app_info["working-directory"] / map_input
+    # Use POSIX path for input and output paths as local paths are mounted to those paths in the container.
+    map_input = Path(app_info["input"]["path"]).as_posix()
+    map_output = Path(app_info["output"]["path"]).as_posix()
+    if not posixpath.isabs(map_input):
+        map_input = posixpath.join(app_info["working-directory"], map_input)
 
-    if not map_output.is_absolute():
-        map_output = app_info["working-directory"] / map_output
+    if not posixpath.isabs(map_output):
+        map_output = posixpath.join(app_info["working-directory"], map_output)
 
     cmd += f' -e MONAI_INPUTPATH="{map_input}"'
     cmd += f' -e MONAI_OUTPUTPATH="{map_output}"'

--- a/monai/deploy/runner/utils.py
+++ b/monai/deploy/runner/utils.py
@@ -10,7 +10,6 @@
 # limitations under the License.
 
 import logging
-import shlex
 import subprocess
 
 logger = logging.getLogger("app_runner")
@@ -41,8 +40,7 @@ def run_cmd(cmd: str) -> int:
     Returns:
         output: child process returncode after the command has been executed.
     """
-    args = shlex.split(cmd)
-    proc = subprocess.Popen(args, universal_newlines=True)
+    proc = subprocess.Popen(cmd, universal_newlines=True, shell=True)
     return proc.wait()
 
 


### PR DESCRIPTION
- Use POSIX path for App Runner 
- Do not use shlex.quote for Windows
- Update .bumpversion.cfg to sign-off commit 
- Bump version to `0.1.1rc2 `

Created `0.1.1rc2` package on test PyPI for test.
```bash
pip install -i https://test.pypi.org/simple/ monai-deploy-app-sdk==0.1.1rc2
```

resolve #152
