### PR TITLE
fix: PNGConverterOperator uses the wrong axis dimension

### DIFF
--- a/monai/deploy/operators/png_converter_operator.py
+++ b/monai/deploy/operators/png_converter_operator.py
@@ -44,7 +44,7 @@ class PNGConverterOperator(Operator):
         image_data = image.asnumpy()
         image_shape = image_data.shape
 
-        num_images = image_shape[0]
+        num_images = image_shape[2]
 
         for i in range(0, num_images):
             input_data = image_data[:, :, i]


### PR DESCRIPTION
Hi everyone,

After looking at the very interesting MONAI Bootcamp videos I wanted to test out the MONAI Deploy SDK and very quickly hit a minor issue. The PNG Converter is using the wrong image axis when it sets up the loop, so if you have an image where axis 0 and axis 2 have different lengths, it throws an error (along the lines of `IndexError: index 261 is out of bounds for axis 2 with size 261`) and fails to produce all of the PNGs.

Thanks!