### PR TITLE
Upload code coverage using CodeCov

### DIFF
--- a/.azure/azure-build-pipeline.yml
+++ b/.azure/azure-build-pipeline.yml
@@ -1,7 +1,7 @@
 trigger:
 - main
 
-pr: 
+pr:
 - main
 
 stages:
@@ -25,14 +25,25 @@ stages:
           virtualenv .venv
         displayName: 'Create Venv'
       - script: |
-          source .venv/bin/activate 
+          source .venv/bin/activate
           ./run setup
         displayName: 'Setup development environment'
-      - script: | 
-          source .venv/bin/activate 
+      - script: |
+          source .venv/bin/activate
           ./run check -f
         displayName: 'Check formatting'
-      - script: |   
-          source .venv/bin/activate 
+      - script: |
+          source .venv/bin/activate
           ./run test all unit
         displayName: 'Run Unit tests'
+      - script: |
+          # Refer to https://about.codecov.io/blog/introducing-codecovs-new-uploader/
+          curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --import # One-time step
+          curl -Os https://uploader.codecov.io/latest/linux/codecov
+          curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+          curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+          gpg --verify codecov.SHA256SUM.sig codecov.SHA256SUM
+          shasum -a 256 -c codecov.SHA256SUM
+          chmod +x codecov
+          ./codecov -f monai-deploy-app-sdk-coverage.xml -t $(CODECOV_TOKEN)
+        displayName: 'Upload code coverage'


### PR DESCRIPTION
Since coverage report (`monai-deploy-app-sdk-coverage.xml` here) is generated by Azure Pipeline, we cannot use Github Action for uploading coverage result:
https://github.com/codecov/codecov-action

Instead, this uploads code coverage by using codecov uploader binary.
Since the new codecov uploader binary is quite large (64MB), it may not efficient (+~5 seconds for download) as the [old bash codecov uploader](https://docs.codecov.com/docs/about-the-codecov-bash-uploader).

Also added `CODECOV_TOKEN` secret variable to Azure Pipeline (Build+Test): https://dev.azure.com/projectmonai/monai-deploy-app-sdk/_apps/hub/ms.vss-build-web.ci-designer-hub?pipelineId=9

Reference:
- https://about.codecov.io/blog/introducing-codecovs-new-uploader/
- https://devblogs.microsoft.com/devops/uploading-to-codecov-just-got-easier/  <== uses old bash uploader that will be deprecated on February 1, 2022
- https://about.codecov.io/blog/how-to-set-up-codecov-with-c-and-azure-pipelines/
- https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#secret-variables