### PR TITLE
Build package with local UID/GID and fast-retrieve app/package information

### DIFF
--- a/monai/deploy/packager/util.py
+++ b/monai/deploy/packager/util.py
@@ -229,10 +229,12 @@ def build_image(args: dict, temp_dir: str):
         dockerignore_file.write(docker_ignore_template)
 
     # Build dockerfile into an MAP image
-    docker_build_cmd = ["docker", "build", "-f", docker_file_path, "-t", tag, temp_dir]
+    docker_build_cmd = f'''docker build -f "{docker_file_path}" -t {tag} "{temp_dir}"'''
+    if sys.platform != "win32":
+        docker_build_cmd += """ --build-arg MONAI_UID=$(id -u) --build-arg MONAI_GID=$(id -g)"""
     if no_cache:
-        docker_build_cmd.append("--no-cache")
-    proc = subprocess.Popen(docker_build_cmd, stdout=subprocess.PIPE)
+        docker_build_cmd += " --no-cache"
+    proc = subprocess.Popen(docker_build_cmd, stdout=subprocess.PIPE, shell=True)
 
     spinner = ProgressSpinner("Building MONAI Application Package... ")
     spinner.start()


### PR DESCRIPTION
MAP is created with the default UID/GID (1000) by default.
However, if the user has UID which is not 1000 such as 1001, the local input/output folder is mounted with the host's input folder permission (1001) by App Runner and causes the following message when MAP is executed.

```bash
...
Reading MONAI App Package manifest...
 > export '/var/run/monai/export/' detected
fatal: Access to the path '/var/run/monai/export/config/pkg.json' is denied.
ERROR: Failed to fetch MAP manifest.
Execution Aborted
```

This patch builds a Docker image with local UID/GID to resolve the issue.

Also, it retrieves app/package information with the faster method if the OS is not Windows.
(copying app.json/pkg.json through `docker cp` command is faster than launching container to download config file).

```python
        if sys.platform == "win32":
            cmd = f"docker run --rm -a STDOUT -a STDERR -v {info_dir}:/var/run/monai/export/config {map_name}"
        else:
            cmd = f"""docker_id=$(docker create {map_name})
docker cp $docker_id:/etc/monai/app.json {info_dir}/app.json
docker cp $docker_id:/etc/monai/pkg.json {info_dir}/pkg.json
docker rm -v $docker_id > /dev/null
"""
```
The bug is confirmed and tested by creating AWS EC2 instance:

```
AMI: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210430
Instance type: t2.large
Storage: 20 GB 
```
Due to large base image size, only 1.3GB was left after exercise the Tutorial 1 (examples/apps/simple_imaging_app):
```
(monai) gbae@ip-172-31-0-144:~/monai-deploy-app-sdk$ df
Filesystem     1K-blocks     Used Available Use% Mounted on
/dev/root       20263484 18888788   1358312  94% /
devtmpfs         4069584        0   4069584   0% /dev
tmpfs            4075372        0   4075372   0% /dev/shm
tmpfs             815076      832    814244   1% /run
tmpfs               5120        0      5120   0% /run/lock
tmpfs            4075372        0   4075372   0% /sys/fs/cgroup
/dev/loop0         56832    56832         0 100% /snap/core18/1997
/dev/loop1         34176    34176         0 100% /snap/amazon-ssm-agent/3552
/dev/loop2         33152    33152         0 100% /snap/snapd/11588
/dev/loop3         72192    72192         0 100% /snap/lxd/19647
tmpfs             815072        0    815072   0% /run/user/1001
```


This patch is verified in the AWS EC2 instance by using the following test package:

```bash
pip install -i https://test.pypi.org/simple/ monai-deploy-app-sdk==0.0.165
```

Resolves https://github.com/Project-MONAI/monai-deploy-app-sdk/issues/165

P.S. It might be better to use 'docker' client library instead of executing docker with shell command. We will address the issue later.