### PR TITLE
Release v0.1.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.1
+current_version = 0.2.0a1
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<release>a|b|rc)(?P<build>\d+))?
 serialize = 
 	{major}.{minor}.{patch}{release}{build}


### PR DESCRIPTION
- Release current origin/main as v0.1.1 (tagging `0.1.1`)
- Create `v0.1` and `v0.1.1` branches for tracking the version.
- Create a tag 0.2.0a1 for v0.2.0 development on `main` branch.
![image](https://user-images.githubusercontent.com/1928522/138756011-e291bdc6-94e5-4d9a-943c-8ca5a9e927d4.png)

v0.1.1 has the following changes, compared with v0.1.0

- #189
- #188
- #186
- #183
- #182
- #173
- #164
- #158
- #153

Addresses #184