### PR TITLE
Bump numpy >= 1.20 to avoid MKL error in conda env, and add --upgrade for pip install app sdk

### DIFF
--- a/examples/apps/ai_livertumor_seg_app/livertumor_seg_operator.py
+++ b/examples/apps/ai_livertumor_seg_app/livertumor_seg_operator.py
@@ -34,7 +34,7 @@ from monai.transforms import (
 @md.input("image", Image, IOType.IN_MEMORY)
 @md.output("seg_image", Image, IOType.IN_MEMORY)
 @md.output("saved_images_folder", DataPath, IOType.DISK)
-@md.env(pip_packages=["monai==0.6.0", "torch>=1.5", "numpy>=1.17", "nibabel"])
+@md.env(pip_packages=["monai==0.6.0", "torch>=1.5", "numpy>=1.20", "nibabel"])
 class LiverTumorSegOperator(Operator):
     """Performs liver and tumor segmentation using a DL model with an image converted from a DICOM CT series.
 

--- a/examples/apps/ai_spleen_seg_app/spleen_seg_operator.py
+++ b/examples/apps/ai_spleen_seg_app/spleen_seg_operator.py
@@ -34,7 +34,7 @@ from monai.transforms import (
 
 @md.input("image", Image, IOType.IN_MEMORY)
 @md.output("seg_image", Image, IOType.IN_MEMORY)
-@md.env(pip_packages=["monai==0.6.0", "torch>=1.5", "numpy>=1.17", "nibabel"])
+@md.env(pip_packages=["monai==0.6.0", "torch>=1.5", "numpy>=1.20", "nibabel"])
 class SpleenSegOperator(Operator):
     """Performs Spleen segmentation with a 3D image converted from a DICOM CT series.
 

--- a/examples/apps/ai_unetr_seg_app/unetr_seg_operator.py
+++ b/examples/apps/ai_unetr_seg_app/unetr_seg_operator.py
@@ -35,7 +35,7 @@ from monai.transforms import (
 @md.input("image", Image, IOType.IN_MEMORY)
 @md.output("seg_image", Image, IOType.IN_MEMORY)
 @md.output("saved_images_folder", DataPath, IOType.DISK)
-@md.env(pip_packages=["monai==0.6.0", "torch>=1.5", "numpy>=1.17", "nibabel"])
+@md.env(pip_packages=["monai==0.6.0", "torch>=1.5", "numpy>=1.20", "nibabel"])
 class UnetrSegOperator(Operator):
     """Performs multi-organ segmentation using UNETR model with an image converted from a DICOM CT series.
 

--- a/examples/apps/deply_app_on_aarch64_interim.md
+++ b/examples/apps/deply_app_on_aarch64_interim.md
@@ -31,7 +31,7 @@ Without using the MONAI Deploy App SDK Packager to automatically detect the depe
 monai>=0.6.0
 monai-deploy-app-sdk>=0.1.0
 nibabel
-numpy>=1.17
+numpy>=1.20
 pydicom>=1.4.2
 torch>=1.5
 ```

--- a/monai/deploy/operators/monai_seg_inference_operator.py
+++ b/monai/deploy/operators/monai_seg_inference_operator.py
@@ -41,7 +41,7 @@ __all__ = ["MonaiSegInferenceOperator", "InMemImageReader"]
 
 @md.input("image", Image, IOType.IN_MEMORY)
 @md.output("seg_image", Image, IOType.IN_MEMORY)
-@md.env(pip_packages=["monai==0.6.0", "torch>=1.5", "numpy>=1.17"])
+@md.env(pip_packages=["monai==0.6.0", "torch>=1.5", "numpy>=1.20"])
 class MonaiSegInferenceOperator(InferenceOperator):
     """This segmentation operator uses MONAI transforms and Sliding Window Inference.
 

--- a/notebooks/tutorials/03_segmentation_app.ipynb
+++ b/notebooks/tutorials/03_segmentation_app.ipynb
@@ -99,14 +99,14 @@
     "# Install MONAI and other necessary image processing packages for the application\n",
     "!python -c \"import monai\" || pip install -q \"monai\"\n",
     "!python -c \"import torch\" || pip install -q \"torch>=1.5\"\n",
-    "!python -c \"import numpy\" || pip install -q \"numpy>=1.17\"\n",
+    "!python -c \"import numpy\" || pip install -q \"numpy>=1.20\"\n",
     "!python -c \"import nibabel\" || pip install -q \"nibabel>=3.2.1\"\n",
     "!python -c \"import pydicom\" || pip install -q \"pydicom>=1.4.2\"\n",
     "!python -c \"import SimpleITK\" || pip install -q \"SimpleITK>=2.0.0\"\n",
     "!python -c \"import typeguard\" || pip install -q \"typeguard>=2.12.1\"\n",
     "\n",
     "# Install MONAI Deploy App SDK package\n",
-    "!python -c \"import monai.deploy\" || pip install -q \"monai-deploy-app-sdk\""
+    "!python -c \"import monai.deploy\" || pip install --upgrade -q \"monai-deploy-app-sdk\""
    ]
   },
   {
@@ -747,7 +747,7 @@
    "source": [
     "@md.input(\"image\", Image, IOType.IN_MEMORY)\n",
     "@md.output(\"seg_image\", Image, IOType.IN_MEMORY)\n",
-    "@md.env(pip_packages=[\"monai==0.6.0\", \"torch>=1.5\", \"numpy>=1.17\", \"nibabel\"])\n",
+    "@md.env(pip_packages=[\"monai==0.6.0\", \"torch>=1.5\", \"numpy>=1.20\", \"nibabel\"])\n",
     "class SpleenSegOperator(Operator):\n",
     "    \"\"\"Performs Spleen segmentation with a 3D image converted from a DICOM CT series.\n",
     "    \"\"\"\n",
@@ -1025,7 +1025,7 @@
     "\n",
     "@md.input(\"image\", Image, IOType.IN_MEMORY)\n",
     "@md.output(\"seg_image\", Image, IOType.IN_MEMORY)\n",
-    "@md.env(pip_packages=[\"monai==0.6.0\", \"torch>=1.5\", \"numpy>=1.17\", \"nibabel\", \"typeguard\"])\n",
+    "@md.env(pip_packages=[\"monai==0.6.0\", \"torch>=1.5\", \"numpy>=1.20\", \"nibabel\", \"typeguard\"])\n",
     "class SpleenSegOperator(Operator):\n",
     "    \"\"\"Performs Spleen segmentation with a 3D image converted from a DICOM CT series.\n",
     "    \"\"\"\n",

--- a/notebooks/tutorials/05_full_tutorial.ipynb
+++ b/notebooks/tutorials/05_full_tutorial.ipynb
@@ -89,7 +89,7 @@
     "# Install MONAI and other necessary image processing packages for the application\n",
     "!python -c \"import monai\" || pip install -q \"monai\"\n",
     "!python -c \"import torch\" || pip install -q \"torch>=1.5\"\n",
-    "!python -c \"import numpy\" || pip install -q \"numpy>=1.17\"\n",
+    "!python -c \"import numpy\" || pip install -q \"numpy>=1.20\"\n",
     "!python -c \"import nibabel\" || pip install -q \"nibabel>=3.2.1\"\n",
     "!python -c \"import pydicom\" || pip install -q \"pydicom>=1.4.2\"\n",
     "!python -c \"import SimpleITK\" || pip install -q \"SimpleITK>=2.0.0\"\n",
@@ -97,7 +97,7 @@
     "!python -c \"import nilearn\" || pip install -q \"nilearn>=0.8.1\"\n",
     "\n",
     "# Install MONAI Deploy App SDK package\n",
-    "!python -c \"import monai.deploy\" || pip install -q \"monai-deploy-app-sdk\""
+    "!python -c \"import monai.deploy\" || pip install --upgrade -q \"monai-deploy-app-sdk\""
    ]
   },
   {
@@ -738,7 +738,7 @@
    "source": [
     "@md.input(\"image\", Image, IOType.IN_MEMORY)\n",
     "@md.output(\"seg_image\", Image, IOType.IN_MEMORY)\n",
-    "@md.env(pip_packages=[\"monai==0.6.0\", \"torch>=1.5\", \"numpy>=1.17\", \"nibabel\"])\n",
+    "@md.env(pip_packages=[\"monai==0.6.0\", \"torch>=1.5\", \"numpy>=1.20\", \"nibabel\"])\n",
     "class SpleenSegOperator(Operator):\n",
     "    \"\"\"Performs Spleen segmentation with a 3D image converted from a DICOM CT series.\n",
     "    \"\"\"\n",
@@ -1016,7 +1016,7 @@
     "\n",
     "@md.input(\"image\", Image, IOType.IN_MEMORY)\n",
     "@md.output(\"seg_image\", Image, IOType.IN_MEMORY)\n",
-    "@md.env(pip_packages=[\"monai==0.6.0\", \"torch>=1.5\", \"numpy>=1.17\", \"nibabel\", \"typeguard\"])\n",
+    "@md.env(pip_packages=[\"monai==0.6.0\", \"torch>=1.5\", \"numpy>=1.20\", \"nibabel\", \"typeguard\"])\n",
     "class SpleenSegOperator(Operator):\n",
     "    \"\"\"Performs Spleen segmentation with a 3D image converted from a DICOM CT series.\n",
     "    \"\"\"\n",


### PR DESCRIPTION
It was found out that when running Jupyter-lab within a environment set up using conda, pytorch encountered error related to MKL, see [pytorch issue](https://github.com/pytorch/pytorch/issues/37377).

A previous [PR ](https://github.com/Project-MONAI/monai-deploy-app-sdk/pull/208) modified the Jupyter notebook adding env var ['MKL_THREADING_LAYER'] = 'GNU' to work around the MKL issue, which is one of the suggested fixes.

A cleaner fix, as also [stated in the said issue](https://github.com/pytorch/pytorch/issues/37377#issuecomment-807271090), is to upgrade to numpy 1.20 to avoid the MKL issue without needing the env var workaround.

The example segmentation examples had already been tested with numpy >= 1.20, so it is the safe and correct fix to bump the numpy version >= 1.20, in the apps, as well as in the Jupyter notebooks that copied the app code.

Also added `--upgrade` option for pip install monai-deploy-app-sdk, in case the env had an earlier version of the sdk installed.