### PR TITLE
Change the model name in the Spleen seg example dataset to model.ts

### DIFF
--- a/docs/source/getting_started/tutorials/03_segmentation_app.md
+++ b/docs/source/getting_started/tutorials/03_segmentation_app.md
@@ -50,25 +50,25 @@ cd monai-deploy-app-sdk
 # Install monai-deploy-app-sdk package
 pip install monai-deploy-app-sdk
 
-# Download/Extract ai_spleen_seg_data.zip from https://drive.google.com/file/d/1uTQsm8omwimBcp_kRXlduWBP2M6cspr1/view?usp=sharing
+# Download/Extract ai_spleen_seg_data zip file from https://drive.google.com/file/d/1GC_N8YQk_mOWN02oOzAU_2YDmNRWk--n/view?usp=sharing
 
 # Download ai_spleen_seg_data.zip
 pip install gdown
-gdown https://drive.google.com/uc?id=1uTQsm8omwimBcp_kRXlduWBP2M6cspr1
+gdown https://drive.google.com/uc?id=1GC_N8YQk_mOWN02oOzAU_2YDmNRWk--n
 
 # After downloading ai_spleen_seg_data.zip from the web browser or using gdown,
-unzip -o ai_spleen_seg_data.zip
+unzip -o ai_spleen_seg_data_updated_1203.zip
 
 # Install necessary packages from the app
 pip install monai pydicom SimpleITK Pillow nibabel
 
 # Local execution of the app
-python examples/apps/ai_spleen_seg_app/app.py -i dcm/ -o output -m model.pt
+python examples/apps/ai_spleen_seg_app/app.py -i dcm/ -o output -m model.ts
 
 # Package app (creating MAP docker image) using `-l DEBUG` option to see progress.
 # This assumes that nvidia docker is installed in the local machine.
 # Please see https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker to install nvidia-docker2.
-monai-deploy package examples/apps/ai_spleen_seg_app --tag seg_app:latest --model model.pt -l DEBUG
+monai-deploy package examples/apps/ai_spleen_seg_app --tag seg_app:latest --model model.ts -l DEBUG
 
 # Run the app with docker image and input file locally
 monai-deploy run seg_app:latest dcm/ output

--- a/notebooks/tutorials/03_segmentation_app.ipynb
+++ b/notebooks/tutorials/03_segmentation_app.ipynb
@@ -137,10 +137,10 @@
       "Requirement already satisfied: urllib3<1.27,>=1.21.1 in /home/gbae/miniconda3/envs/mednist/lib/python3.6/site-packages (from requests[socks]>=2.12.0->gdown) (1.26.6)\n",
       "Requirement already satisfied: PySocks!=1.5.7,>=1.5.6 in /home/gbae/miniconda3/envs/mednist/lib/python3.6/site-packages (from requests[socks]>=2.12.0->gdown) (1.7.1)\n",
       "Downloading...\n",
-      "From: https://drive.google.com/uc?id=1uTQsm8omwimBcp_kRXlduWBP2M6cspr1\n",
-      "To: /home/gbae/repo/monai-deploy-app-sdk/notebooks/tutorials/ai_spleen_seg_data.zip\n",
+      "From: https://drive.google.com/uc?id=1GC_N8YQk_mOWN02oOzAU_2YDmNRWk--n\n",
+      "To: /home/gbae/repo/monai-deploy-app-sdk/notebooks/tutorials/ai_spleen_seg_data_update_1203.zip\n",
       "104MB [00:10, 10.3MB/s] \n",
-      "Archive:  ai_spleen_seg_data.zip\n",
+      "Archive:  ai_spleen_seg_data_updated_1203.zip\n",
       "   creating: dcm/\n",
       "  inflating: dcm/IMG0001.dcm         \n",
       "  inflating: dcm/IMG0002.dcm         \n",
@@ -657,17 +657,17 @@
       "  inflating: dcm/IMG0513.dcm         \n",
       "  inflating: dcm/IMG0514.dcm         \n",
       "  inflating: dcm/IMG0515.dcm         \n",
-      "  inflating: model.pt                \n"
+      "  inflating: model.ts                \n"
      ]
     }
    ],
    "source": [
-    "# Download ai_spleen_seg_data.zip\n",
+    "# Download ai_spleen_seg_data test data zip file\n",
     "!pip install gdown \n",
-    "!gdown https://drive.google.com/uc?id=1uTQsm8omwimBcp_kRXlduWBP2M6cspr1\n",
+    "!gdown https://drive.google.com/uc?id=1GC_N8YQk_mOWN02oOzAU_2YDmNRWk--n\n",
     "\n",
-    "# After downloading ai_spleen_seg_data.zip from the web browser or using gdown,\n",
-    "!unzip -o \"ai_spleen_seg_data.zip\""
+    "# After downloading ai_spleen_seg_data zip file from the web browser or using gdown,\n",
+    "!unzip -o \"ai_spleen_seg_data_updated_1203.zip\""
    ]
   },
   {
@@ -873,7 +873,7 @@
    "source": [
     "## Executing app locally\n",
     "\n",
-    "We can execute the app in the Jupyter notebook. Note that the DICOM files of the CT Abdomen series must be present in the `dcm` and the Torch Script model at `model.pt`. Please use the actual path in your environment.\n"
+    "We can execute the app in the Jupyter notebook. Note that the DICOM files of the CT Abdomen series must be present in the `dcm` and the Torch Script model at `model.ts`. Please use the actual path in your environment.\n"
    ]
   },
   {
@@ -988,7 +988,7 @@
    "source": [
     "app = AISpleenSegApp()\n",
     "\n",
-    "app.run(input=\"dcm\", output=\"output\", model=\"model.pt\")"
+    "app.run(input=\"dcm\", output=\"output\", model=\"model.ts\")"
    ]
   },
   {
@@ -1221,7 +1221,7 @@
     "    #     -o <output folder>, for the output folder, default $PWD/output\n",
     "    #     -m <model file>, for model file path\n",
     "    # e.g.\n",
-    "    #     python3 app.py -i input -m model.pt\n",
+    "    #     python3 app.py -i input -m model.ts\n",
     "    #\n",
     "    AISpleenSegApp(do_run=True)"
    ]
@@ -1370,7 +1370,7 @@
     }
    ],
    "source": [
-    "!python my_app -i dcm -o output -m model.pt"
+    "!python my_app -i dcm -o output -m model.ts"
    ]
   },
   {
@@ -1465,7 +1465,7 @@
    "source": [
     "import os\n",
     "os.environ['MKL_THREADING_LAYER'] = 'GNU'\n",
-    "!monai-deploy exec my_app -i dcm -o output -m model.pt"
+    "!monai-deploy exec my_app -i dcm -o output -m model.ts"
    ]
   },
   {
@@ -1514,7 +1514,7 @@
     }
    ],
    "source": [
-    "!monai-deploy package -b nvcr.io/nvidia/pytorch:21.11-py3 my_app --tag my_app:latest -m model.pt"
+    "!monai-deploy package -b nvcr.io/nvidia/pytorch:21.11-py3 my_app --tag my_app:latest -m model.ts"
    ]
   },
   {
@@ -1698,7 +1698,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.13"
+   "version": "3.7.5"
   }
  },
  "nbformat": 4,

--- a/notebooks/tutorials/04_mis_tutorial.ipynb
+++ b/notebooks/tutorials/04_mis_tutorial.ipynb
@@ -113,7 +113,7 @@
       "    \"models\": [\r\n",
       "        {\r\n",
       "            \"name\": \"model-54dd6cdaac290a0e800c0fa627cd60410bb2cea173ac8bb2f4816cc54ea88c90\",\r\n",
-      "            \"path\": \"/opt/monai/models/model/model.pt\"\r\n",
+      "            \"path\": \"/opt/monai/models/model/model.ts\"\r\n",
       "        }\r\n",
       "    ],\r\n",
       "    \"resources\": {\r\n",
@@ -270,7 +270,7 @@
     "| `map.gpu` | Number of GPUs requested by application which can be obtained either from `pkg.json` OR from when we created app.py (check @resource decorator) |\n",
     "| `map.inputPath` | Input volume path within MAP container, can be derived by appending the `input.path` with the `working-directory` in `app.json` |\n",
     "| `map.outputPath` | Output volume path within MAP container, can be derived by appending the `output.path` with the `working-directory` in `app.json` |\n",
-    "| `map.modelPath` | Model volume path within MAP container, can be derived using a `path` of an entry under `models` in `pkg.json`, and taking the sub-path where the `/model` folder resides (ex: `path: \"/opt/monai/models/model/model.pt\"` ->  `\"/opt/monai/models\"`) |"
+    "| `map.modelPath` | Model volume path within MAP container, can be derived using a `path` of an entry under `models` in `pkg.json`, and taking the sub-path where the `/model` folder resides (ex: `path: \"/opt/monai/models/model/model.ts\"` ->  `\"/opt/monai/models\"`) |"
    ]
   },
   {
@@ -452,10 +452,10 @@
       "Requirement already satisfied: soupsieve>1.2 in /home/gupta/miniconda3/envs/monairsna/lib/python3.6/site-packages (from beautifulsoup4->gdown) (2.3.1)\n",
       "Requirement already satisfied: PySocks!=1.5.7,>=1.5.6 in /home/gupta/miniconda3/envs/monairsna/lib/python3.6/site-packages (from requests[socks]->gdown) (1.7.1)\n",
       "Downloading...\n",
-      "From: https://drive.google.com/uc?id=1uTQsm8omwimBcp_kRXlduWBP2M6cspr1\n",
-      "To: /data/Vikash/Tools/RSNA/monai-deploy-app-sdk/notebooks/tutorials/ai_spleen_seg_data.zip\n",
+      "From: https://drive.google.com/uc?id=1GC_N8YQk_mOWN02oOzAU_2YDmNRWk--n\n",
+      "To: /data/Vikash/Tools/RSNA/monai-deploy-app-sdk/notebooks/tutorials/ai_spleen_seg_data_updated_1203.zip\n",
       "100%|████████████████████████████████████████| 104M/104M [00:20<00:00, 4.97MB/s]\n",
-      "Archive:  ai_spleen_seg_data.zip\n",
+      "Archive:  ai_spleen_seg_data_updated_1203.zip\n",
       "  inflating: dcm/IMG0001.dcm         \n",
       "  inflating: dcm/IMG0002.dcm         \n",
       "  inflating: dcm/IMG0003.dcm         \n",
@@ -983,16 +983,16 @@
       "  inflating: dcm/IMG0513.dcm         \n",
       "  inflating: dcm/IMG0514.dcm         \n",
       "  inflating: dcm/IMG0515.dcm         \n",
-      "  inflating: model.pt                \n",
+      "  inflating: model.ts                \n",
       "input.zip\n"
      ]
     }
    ],
    "source": [
-    "# Download ai_spleen_seg_data.zip if not done so already\n",
+    "# Download ai_spleen_seg_data if not done so already\n",
     "!pip install gdown \n",
-    "!gdown https://drive.google.com/uc?id=1uTQsm8omwimBcp_kRXlduWBP2M6cspr1\n",
-    "!unzip -o \"ai_spleen_seg_data.zip\"\n",
+    "!gdown https://drive.google.com/uc?id=1GC_N8YQk_mOWN02oOzAU_2YDmNRWk--n\n",
+    "!unzip -o \"ai_spleen_seg_data_updated_1203.zip\"\n",
     "\n",
     "!cd dcm; zip -rq ../input.zip *\n",
     "!ls input.zip"

--- a/notebooks/tutorials/05_full_tutorial.ipynb
+++ b/notebooks/tutorials/05_full_tutorial.ipynb
@@ -128,10 +128,10 @@
       "Requirement already satisfied: urllib3<1.27,>=1.21.1 in /home/gbae/miniconda3/envs/mednist/lib/python3.6/site-packages (from requests[socks]>=2.12.0->gdown) (1.26.6)\n",
       "Requirement already satisfied: PySocks!=1.5.7,>=1.5.6 in /home/gbae/miniconda3/envs/mednist/lib/python3.6/site-packages (from requests[socks]>=2.12.0->gdown) (1.7.1)\n",
       "Downloading...\n",
-      "From: https://drive.google.com/uc?id=1uTQsm8omwimBcp_kRXlduWBP2M6cspr1\n",
-      "To: /home/gbae/repo/monai-deploy-app-sdk/notebooks/tutorials/ai_spleen_seg_data.zip\n",
+      "From: https://drive.google.com/uc?id=1GC_N8YQk_mOWN02oOzAU_2YDmNRWk--n\n",
+      "To: /home/gbae/repo/monai-deploy-app-sdk/notebooks/tutorials/ai_spleen_seg_data_updated_1203.zip\n",
       "104MB [00:10, 10.3MB/s] \n",
-      "Archive:  ai_spleen_seg_data.zip\n",
+      "Archive:  ai_spleen_seg_data_update_1203.zip\n",
       "   creating: dcm/\n",
       "  inflating: dcm/IMG0001.dcm         \n",
       "  inflating: dcm/IMG0002.dcm         \n",
@@ -648,17 +648,17 @@
       "  inflating: dcm/IMG0513.dcm         \n",
       "  inflating: dcm/IMG0514.dcm         \n",
       "  inflating: dcm/IMG0515.dcm         \n",
-      "  inflating: model.pt                \n"
+      "  inflating: model.ts                \n"
      ]
     }
    ],
    "source": [
-    "# Download ai_spleen_seg_data.zip\n",
+    "# Download ai_spleen_seg_data test data zip file\n",
     "!pip install gdown \n",
-    "!gdown https://drive.google.com/uc?id=1uTQsm8omwimBcp_kRXlduWBP2M6cspr1\n",
+    "!gdown https://drive.google.com/uc?id=1GC_N8YQk_mOWN02oOzAU_2YDmNRWk--n\n",
     "\n",
-    "# After downloading ai_spleen_seg_data.zip from the web browser or using gdown,\n",
-    "!unzip -o \"ai_spleen_seg_data.zip\""
+    "# After downloading ai_spleen_seg_data zip file from the web browser or using gdown,\n",
+    "!unzip -o \"ai_spleen_seg_data_updated_1203.zip\""
    ]
   },
   {
@@ -864,7 +864,7 @@
    "source": [
     "## Executing app locally\n",
     "\n",
-    "We can execute the app in the Jupyter notebook. Note that the DICOM files of the CT Abdomen series must be present in the `dcm` and the Torch Script model at `model.pt`. Please use the actual path in your environment.\n"
+    "We can execute the app in the Jupyter notebook. Note that the DICOM files of the CT Abdomen series must be present in the `dcm` and the Torch Script model at `model.ts`. Please use the actual path in your environment.\n"
    ]
   },
   {
@@ -935,7 +935,7 @@
    "source": [
     "app = AISpleenSegApp()\n",
     "\n",
-    "app.run(input=\"dcm\", output=\"output\", model=\"model.pt\")"
+    "app.run(input=\"dcm\", output=\"output\", model=\"model.ts\")"
    ]
   },
   {
@@ -1168,7 +1168,7 @@
     "    #     -o <output folder>, for the output folder, default $PWD/output\n",
     "    #     -m <model file>, for model file path\n",
     "    # e.g.\n",
-    "    #     python3 app.py -i input -m model.pt\n",
+    "    #     python3 app.py -i input -m model.ts\n",
     "    #\n",
     "    AISpleenSegApp(do_run=True)"
    ]
@@ -1276,7 +1276,7 @@
     }
    ],
    "source": [
-    "!python my_app -i dcm -o output -m model.pt"
+    "!python my_app -i dcm -o output -m model.ts"
    ]
   },
   {
@@ -1328,7 +1328,7 @@
     }
    ],
    "source": [
-    "!monai-deploy exec my_app -i dcm -o output -m model.pt"
+    "!monai-deploy exec my_app -i dcm -o output -m model.ts"
    ]
   },
   {
@@ -1377,7 +1377,7 @@
     }
    ],
    "source": [
-    "!monai-deploy package my_app --tag my_app:latest -m model.pt"
+    "!monai-deploy package my_app --tag my_app:latest -m model.ts"
    ]
   },
   {
@@ -1634,7 +1634,7 @@
       "    \"models\": [\n",
       "        {\n",
       "            \"name\": \"model-54dd6cdaac290a0e800c0fa627cd60410bb2cea173ac8bb2f4816cc54ea88c90\",\n",
-      "            \"path\": \"/opt/monai/models/model/model.pt\"\n",
+      "            \"path\": \"/opt/monai/models/model/model.ts\"\n",
       "        }\n",
       "    ],\n",
       "    \"resources\": {\n",
@@ -1791,7 +1791,7 @@
     "| `map.gpu` | Number of GPUs requested by application which can be obtained either from `pkg.json` OR from when we created app.py (check @resource decorator) |\n",
     "| `map.inputPath` | Input volume path within MAP container, can be derived by appending the `input.path` with the `working-directory` in `app.json` |\n",
     "| `map.outputPath` | Output volume path within MAP container, can be derived by appending the `output.path` with the `working-directory` in `app.json` |\n",
-    "| `map.modelPath` | Model volume path within MAP container, can be derived using a `path` of an entry under `models` in `pkg.json`, and taking the sub-path where the `/model` folder resides (ex: `path: \"/opt/monai/models/model/model.pt\"` ->  `\"/opt/monai/models\"`) |"
+    "| `map.modelPath` | Model volume path within MAP container, can be derived using a `path` of an entry under `models` in `pkg.json`, and taking the sub-path where the `/model` folder resides (ex: `path: \"/opt/monai/models/model/model.ts\"` ->  `\"/opt/monai/models\"`) |"
    ]
   },
   {


### PR DESCRIPTION
This is to avoid confusion as the .pt and .ts are used by some model sources to distinguish PyTorch and TorchScript model files, e.g. Clara MMAR.

A new dataset zip file has been uploaded to Google drive, and the Jupyter notebooks in the tutorials have been updated to download the new zip file and use the updated model file name. The original dataset zip file is still available on the Google drive, in case existing version of the Spleen Seg Jupyter notebook is used.

Noted again that Jupyter notebooks 04 and 05 copied some steps from the Spleen Seg; the duplication inevitably causes duplicated effort when the source changes.      

Signed-off-by: mmelqin <mingmelvinq@nvidia.com>