### PR TITLE
Handle exception case with missing DICOM Rescale Intercept and Slope attributes

### DIFF
--- a/monai/deploy/operators/dicom_series_to_volume_operator.py
+++ b/monai/deploy/operators/dicom_series_to_volume_operator.py
@@ -89,6 +89,7 @@ class DICOMSeriesToVolumeOperator(Operator):
             intercept = slices[0][0x0028, 0x1052].value
         except KeyError:
             intercept = 0
+
         try:
             slope = slices[0][0x0028, 0x1053].value
         except KeyError:

--- a/monai/deploy/operators/dicom_series_to_volume_operator.py
+++ b/monai/deploy/operators/dicom_series_to_volume_operator.py
@@ -84,8 +84,15 @@ class DICOMSeriesToVolumeOperator(Operator):
         # This is to have the same numpy ndarray as from Monai ImageReader (ITK, NiBabel etc).
         vol_data = np.stack([np.transpose(s.get_pixel_array()) for s in slices], axis=-1)
         vol_data = vol_data.astype(np.int16)
-        intercept = slices[0][0x0028, 0x1052].value
-        slope = slices[0][0x0028, 0x1053].value
+        # Rescale Intercept and Slope attributes might be missing, but safe to assume defaults.
+        try:
+            intercept = slices[0][0x0028, 0x1052].value
+        except KeyError:
+            intercept = 0
+        try:
+            slope = slices[0][0x0028, 0x1053].value
+        except KeyError:
+            slope = 1
 
         if slope != 1:
             vol_data = slope * vol_data.astype(np.float64)


### PR DESCRIPTION
Per Issue [#187](https://github.com/Project-MONAI/monai-deploy-app-sdk/issues/187), added exception handling when parsing Rescale Intercept (0028,1052) and Rescale Slope (0028,1053).

- Rescale Intercept (0028,1052) is of Type 1C. It is required if Modality LUT Sequence (0028,3000) is not present, and shall not be present otherwise.
- Rescale Slope (0028,1053) is also Type 1C, required if Rescale Intercept is present. 
- Rescale Type (0028, 1054) is not parsed or used in the implementation as of now. This attribute is required if Rescale Intercept is present.

These attributes have been observed missing, even in the absence of LUT, in DICOM instances generated with open source utility tools that converts NIfTI image to DICOM. It is safe to use 0 and 1 for the intercept and slope to handle the exception.

The code change has been tested successfully with a DICOM series known to be missing the said attributes.

Note: the build/test failure is due to mypy checking, and the errors are from the runner and packager, not in the modules affected by this PR, as shown below.
```
Checking styles using mypy...
2022-01-12 07:36:06 $ python3 -m mypy --version
mypy 0.931
2022-01-12 07:36:07 $ python3 -m mypy --namespace-packages --explicit-package-bases /home/runner/work/monai-deploy-app-sdk/monai-deploy-app-sdk
monai/deploy/runner/run_command.py:44:5: error: Returning Any from function declared to return "ArgumentParser"  [no-any-return]
monai/deploy/packager/package_command.py:48:5: error: Returning Any from function declared to return "ArgumentParser"  [no-any-return]
monai/deploy/cli/exec_command.py:55:5: error: Returning Any from function declared to return "ArgumentParser"  [no-any-return]
Found 3 errors in 3 files (checked 112 source files)
mypy check failed!
Error: Process completed with exit code 1.
```