### PR TITLE
Fix IPython detection routine

### DIFF
--- a/monai/deploy/core/application.py
+++ b/monai/deploy/core/application.py
@@ -95,7 +95,7 @@ class Application(ABC):
             self.path = get_class_file_path(self.__class__)
 
         # Set the runtime environment
-        if str(self.path).startswith("<ipython-"):
+        if str(self.path) == "ipython":
             self.in_ipython = True
         else:
             self.in_ipython = False

--- a/monai/deploy/utils/importutil.py
+++ b/monai/deploy/utils/importutil.py
@@ -99,7 +99,11 @@ def get_application(path: Union[str, Path]) -> Optional["Application"]:
 def get_class_file_path(cls: Type) -> Path:
     """Get the file path of a class.
 
-    If file path is not available, it tries to get the internal class name used in IPython(starting with <ipython-...>).
+    If the file path is not available, it tries to see each frame information
+    in the stack to check whether the file name ends with "interactiveshell.py"
+    and the function name is "run_code".
+    If so, it returns Path("ipython") to notify that the class is defined
+    inside IPython.
 
     Args:
         cls (Type): A class to get file path from.
@@ -114,8 +118,8 @@ def get_class_file_path(cls: Type) -> Path:
         # If in IPython shell, use inspect.stack() to get the caller's file path
         stack = inspect.stack()
         for frame in stack:
-            if frame.filename.startswith("<ipython-"):
-                return Path(frame.filename)
+            if frame.filename.endswith("interactiveshell.py") and frame.function == "run_code":
+                return Path("ipython")
         # If not in IPython shell, re-raise the error
         raise
 


### PR DESCRIPTION
To detect if the code is run inside Jupyter notebook (IPython) or not, it tried to find whether the class's file name starts with `<ipython-` or not.

Meanwhile the approach worked on Google Colab and some Jupyter Notebook versions. There were some cases where the class's file name is like `/tmp/ipykernel_xxxxx/xxxxxxxxx.py` causing the failure described in #206.

This patch uses a different approach.

If the file path is not available, it tries to see each frame information in the stack to check whether the file name ends with "interactiveshell.py" and the function name is "run_code".

If so, it returns `Path("ipython")` to notify that the class is defined inside IPython.

Fixes #206
Signed-off-by: Gigon Bae <gbae@nvidia.com>

