### PR TITLE
Use Python 3.7 for JupyterLab

### DIFF
--- a/docs/source/getting_started/tutorials/01_simple_app.md
+++ b/docs/source/getting_started/tutorials/01_simple_app.md
@@ -3,8 +3,8 @@
 ## Setup
 
 ```bash
-# Create a virtual environment. Skip if you are already in a virtual environment.
-conda create -n monai python=3.6 pytorch torchvision jupyterlab cudatoolkit=11.1 -c pytorch -c conda-forge
+# Create a virtual environment. Skip if you are already in a virtual environment. (Jupyterlab dropped its support for Python 3.6 since 2021-12-23. See https://github.com/jupyterlab/jupyterlab/pull/11740)
+conda create -n monai python=3.7 pytorch torchvision jupyterlab cudatoolkit=11.1 -c pytorch -c conda-forge
 conda activate monai
 
 # Launch JupyterLab if you want to work on Jupyter Notebook

--- a/docs/source/getting_started/tutorials/02_mednist_app.md
+++ b/docs/source/getting_started/tutorials/02_mednist_app.md
@@ -3,8 +3,11 @@
 ## Setup
 
 ```bash
-# Create a virtual environment. Skip if you are already in a virtual environment.
-conda create -n mednist python=3.6 pytorch jupyterlab cudatoolkit=11.1 -c pytorch -c conda-forge
+# Create a virtual environment with Python 3.7.
+# Skip if you are already in a virtual environment.
+# (JupyterLab dropped its support for Python 3.6 since 2021-12-23.
+#  See https://github.com/jupyterlab/jupyterlab/pull/11740)
+conda create -n mednist python=3.7 pytorch jupyterlab cudatoolkit=11.1 -c pytorch -c conda-forge
 conda activate mednist
 
 # Launch JupyterLab if you want to work on Jupyter Notebook

--- a/docs/source/getting_started/tutorials/03_segmentation_app.md
+++ b/docs/source/getting_started/tutorials/03_segmentation_app.md
@@ -3,8 +3,11 @@
 ## Setup
 
 ```bash
-# Create a virtual environment. Skip if you are already in a virtual environment.
-conda create -n monai python=3.6 pytorch torchvision jupyterlab cudatoolkit=11.1 -c pytorch -c conda-forge
+# Create a virtual environment with Python 3.7.
+# Skip if you are already in a virtual environment.
+# (JupyterLab dropped its support for Python 3.6 since 2021-12-23.
+#  See https://github.com/jupyterlab/jupyterlab/pull/11740)
+conda create -n monai python=3.7 pytorch torchvision jupyterlab cudatoolkit=11.1 -c pytorch -c conda-forge
 conda activate monai
 
 # Launch JupyterLab if you want to work on Jupyter Notebook


### PR DESCRIPTION
[JupyterLab dropped its support for Python 3.6](https://github.com/jupyterlab/jupyterlab/pull/11740) 
(Jupyter notebook still works on Python 3.6).
- https://github.com/jupyterlab/jupyterlab/pull/11740
- https://github.com/jupyter/notebook/blob/master/notebook/traittypes.py#L17
- https://github.com/jupyter-server/jupyter_server/blob/main/jupyter_server/traittypes.py#L7

Update document to use Python 3.7 for JupyterLab.

Fixes #240

Signed-off-by: Gigon Bae <gbae@nvidia.com>