### PR TITLE
Do not upgrade packages when packaging

### DIFF
--- a/monai/deploy/packager/templates.py
+++ b/monai/deploy/packager/templates.py
@@ -41,7 +41,7 @@ COMMON_FOOTPRINT = """
     USER monai
     ENV PATH=/home/monai/.local/bin:$PATH
 
-    RUN pip install --no-cache-dir --upgrade -r {map_requirements_path}
+    RUN pip install --no-cache-dir -r {map_requirements_path}
 
     # Override monai-deploy-app-sdk module
     COPY --chown=monai:monai ./monai-deploy-app-sdk /home/monai/.local/lib/python3.8/site-packages/monai/deploy/


### PR DESCRIPTION
By default, app packager is using `nvcr.io/nvidia/pytorch:21.07-py3` as a base image and the image already has PyTorch that were manually compiled by NVIDIA to support latest architectures such as Amphere.
- https://docs.nvidia.com/deeplearning/frameworks/support-matrix/index.html

Since `--upgrade` was used in `pip` command to install necessary packages, `pytorch` is upgraded but with wring configuration (1.10.1+cu102) when installing PyTorch requires [additional instructions](https://pytorch.org/get-started/locally/) for installation.

This patch removes the option when installing packages so that already-installed packages does not upgrade unless needed.



Signed-off-by: Gigon Bae <gbae@nvidia.com>