### PR TITLE
Drop Python 3.6 support

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.6
+      - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.7
       - name: Setup Dev Environment
         run: |
           pip install virtualenv

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,7 +18,7 @@ sphinx:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.6
+  version: 3.7
   install:
     - requirements: docs/requirements.txt
 #  system_packages: true

--- a/docs/source/getting_started/installing_app_sdk.md
+++ b/docs/source/getting_started/installing_app_sdk.md
@@ -2,7 +2,7 @@
 
 MONAI Deploy App SDK is available as a Python package through [Python Package Index (PyPI)](https://pypi.org/project/monai-deploy-app-sdk/).
 
-MONAI Deploy App SDK's core functionality is written in Python 3 (>= 3.6) for Linux.
+MONAI Deploy App SDK's core functionality is written in Python 3 (>= 3.7) for Linux.
 
 ```bash
 pip install monai-deploy-app-sdk

--- a/docs/source/getting_started/tutorials/01_simple_app.md
+++ b/docs/source/getting_started/tutorials/01_simple_app.md
@@ -3,7 +3,10 @@
 ## Setup
 
 ```bash
-# Create a virtual environment. Skip if you are already in a virtual environment. (Jupyterlab dropped its support for Python 3.6 since 2021-12-23. See https://github.com/jupyterlab/jupyterlab/pull/11740)
+# Create a virtual environment with Python 3.7.
+# Skip if you are already in a virtual environment.
+# (JupyterLab dropped its support for Python 3.6 since 2021-12-23.
+#  See https://github.com/jupyterlab/jupyterlab/pull/11740)
 conda create -n monai python=3.7 pytorch torchvision jupyterlab cudatoolkit=11.1 -c pytorch -c conda-forge
 conda activate monai
 

--- a/docs/srs.md
+++ b/docs/srs.md
@@ -698,7 +698,7 @@ The SDK shall support the following system configurations for a given target rel
 | Docker CE                | 19.03.13+ ([2020-09-16](https://docs.docker.com/engine/release-notes/19.03/#190313)) |
 | NVIDIA Docker            | [v2.5.0+](https://github.com/NVIDIA/nvidia-docker/)                                  |
 | CUDA Compute Capability  | 6.0 or larger (Pascal or newer, including Pascal, Volta, Turing and Ampere families) |
-| Python                   | Python 3.6+                                                                          |
+| Python                   | Python 3.7+                                                                          |
 
 
 ### System Config #2 (Desktop ARM64)
@@ -714,7 +714,7 @@ The SDK shall support the following system configurations for a given target rel
 | Docker CE                | 19.03.13+ ([2020-09-16](https://docs.docker.com/engine/release-notes/19.03/#190313)) |
 | NVIDIA Docker            | [v2.5.0+](https://github.com/NVIDIA/nvidia-docker/)                                  |
 | CUDA Compute Capability  | 6.0 or larger (Pascal or newer, including Pascal, Volta, Turing and Ampere families) |
-| Python                   | Python 3.6+                                                                          |
+| Python                   | Python 3.7+                                                                          |
 
 
 ### System Config #3 (DGX-1)
@@ -730,4 +730,4 @@ The SDK shall support the following system configurations for a given target rel
 | Docker CE                | 19.03.13+ ([2020-09-16](https://docs.docker.com/engine/release-notes/19.03/#190313)) |
 | NVIDIA Docker            | [v2.5.0+](https://github.com/NVIDIA/nvidia-docker/)                                  |
 | CUDA Compute Capability  | 7.0 or larger (Volta or newer, including Volta, Turing and Ampere families)          |
-| Python                   | Python 3.6+                                                                          |
+| Python                   | Python 3.7+                                                                          |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 120
-target-version = ['py36', 'py37', 'py38']
+target-version = ['py37', 'py38', 'py39']
 include = '\.pyi?$'
 exclude = '''
 (

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ project_urls =
     Source Code=https://github.com/Project-MONAI/monai-deploy-app-sdk
 
 [options]
-python_requires = >= 3.6
+python_requires = >= 3.7
 # for compiling and develop setup only
 # no need to specify the versions so that we could
 # compile for multiple targeted versions.


### PR DESCRIPTION
As per MONAI Core's [Python 3.6 drop](https://github.com/Project-MONAI/MONAI/pull/3536), drop the support for Python 3.6 from MONAI Deploy App SDK.

Signed-off-by: Gigon Bae <gbae@nvidia.com>