### PR TITLE
[WIP] Fix MONOCHROME1 Photometric Interpretation

### DIFF
--- a/monai/deploy/core/domain/dicom_sop_instance.py
+++ b/monai/deploy/core/domain/dicom_sop_instance.py
@@ -43,6 +43,15 @@ class DICOMSOPInstance(Domain):
         return self._sop.__getitem__(key)
 
     def get_pixel_array(self):
+        try:
+            pmi = self.get_native_sop_instance().PhotometricInterpretation
+            if pmi == "MONOCHROME1":
+                max_intensity = self._sop.pixel_array.max()
+                shape = self._sop.pixel_array.shape
+                mask = np.full(shape, max_intensity)
+                return mask - self._sop.pixel_array
+        except:
+            pass
         return self._sop.pixel_array
 
     def __str__(self):


### PR DESCRIPTION
DICOM images having Photometric Interpretation of MONOCHROME1 are not inverted by monai-deploy-app-sdk.

The class DICOMSOPInstance reads in pixel_array via pydicom.dcmread(). Pydicom itself does not care about Photometric Interpretation and just delivers the stored pixel array (https://github.com/pydicom/pydicom/issues/783). 

I consider this behavior to be a bug (errorneous inverted images probably will have a huge impact on model's inference performance) and suggest a fix in this PR. Please tell me if there is a better place to put the pixel array inversion of MONOCHROME1 DICOMs.

With this fix DICOMDataloaderOperator reads in MONOCHROME1 images correctly inverted.