### PR TITLE
Fix issue245 DICOM Seg has multiple slices of seg image on the same frame 

### DIFF
--- a/examples/apps/ai_livertumor_seg_app/app.py
+++ b/examples/apps/ai_livertumor_seg_app/app.py
@@ -69,8 +69,6 @@ class AILiverTumorApp(Application):
         # Note the PublisherOperator has temp impl till a proper rendering module is created.
         self.add_flow(unetr_seg_op, publisher_op, {"saved_images_folder": "saved_images_folder"})
         # Note below the dicom_seg_writer requires two inputs, each coming from a upstream operator.
-        # Also note that the DICOMSegmentationWriterOperator may throw exception with some inputs.
-        #   Bug has been created to track the issue.
         self.add_flow(
             series_selector_op, dicom_seg_writer, {"study_selected_series_list": "study_selected_series_list"}
         )

--- a/examples/apps/ai_unetr_seg_app/app.py
+++ b/examples/apps/ai_unetr_seg_app/app.py
@@ -50,7 +50,9 @@ class AIUnetrSegApp(Application):
         # Create the publisher operator
         publisher_op = PublisherOperator()
         # Create the surface mesh STL conversion operator, for all segments
-        stl_conversion_op = STLConversionOperator(output_file="stl/multi-organs.stl", keep_largest_connected_component=False)
+        stl_conversion_op = STLConversionOperator(
+            output_file="stl/multi-organs.stl", keep_largest_connected_component=False
+        )
 
         # Create the processing pipeline, by specifying the upstream and downstream operators, and
         # ensuring the output from the former matches the input of the latter, in both name and type.

--- a/examples/apps/ai_unetr_seg_app/app.py
+++ b/examples/apps/ai_unetr_seg_app/app.py
@@ -15,10 +15,10 @@ from unetr_seg_operator import UnetrSegOperator
 
 from monai.deploy.core import Application, resource
 from monai.deploy.operators.dicom_data_loader_operator import DICOMDataLoaderOperator
-from monai.deploy.operators.dicom_seg_writer_operator import DICOMSegmentationWriterOperator
 from monai.deploy.operators.dicom_series_selector_operator import DICOMSeriesSelectorOperator
 from monai.deploy.operators.dicom_series_to_volume_operator import DICOMSeriesToVolumeOperator
 from monai.deploy.operators.publisher_operator import PublisherOperator
+from monai.deploy.operators.stl_conversion_operator import STLConversionOperator
 
 
 @resource(cpu=1, gpu=1, memory="7Gi")
@@ -49,25 +49,9 @@ class AIUnetrSegApp(Application):
         unetr_seg_op = UnetrSegOperator()
         # Create the publisher operator
         publisher_op = PublisherOperator()
+        # Create the surface mesh STL conversion operator, for all segments
+        stl_conversion_op = STLConversionOperator(output_file="stl/multi-organs.stl", keep_largest_connected_component=False)
 
-        # Creates DICOM Seg writer with segment label name in a string list
-        dicom_seg_writer = DICOMSegmentationWriterOperator(
-            seg_labels=[
-                "spleen",
-                "rkid",
-                "lkid",
-                "gall",
-                "eso",
-                "liver",
-                "sto",
-                "aorta",
-                "IVC",
-                "veins",
-                "pancreas",
-                "rad",
-                "lad",
-            ]
-        )
         # Create the processing pipeline, by specifying the upstream and downstream operators, and
         # ensuring the output from the former matches the input of the latter, in both name and type.
         self.add_flow(study_loader_op, series_selector_op, {"dicom_study_list": "dicom_study_list"})
@@ -75,16 +59,11 @@ class AIUnetrSegApp(Application):
             series_selector_op, series_to_vol_op, {"study_selected_series_list": "study_selected_series_list"}
         )
         self.add_flow(series_to_vol_op, unetr_seg_op, {"image": "image"})
+        self.add_flow(unetr_seg_op, stl_conversion_op, {"seg_image": "image"})
+
         # Add the publishing operator to save the input and seg images for Render Server.
         # Note the PublisherOperator has temp impl till a proper rendering module is created.
         self.add_flow(unetr_seg_op, publisher_op, {"saved_images_folder": "saved_images_folder"})
-        # Note below the dicom_seg_writer requires two inputs, each coming from a upstream operator.
-        # Also note that the DICOMSegmentationWriterOperator may throw exception with some inputs.
-        #   Bug has been created to track the issue.
-        self.add_flow(
-            series_selector_op, dicom_seg_writer, {"study_selected_series_list": "study_selected_series_list"}
-        )
-        self.add_flow(unetr_seg_op, dicom_seg_writer, {"seg_image": "seg_image"})
 
         self._logger.debug(f"End {self.compose.__name__}")
 

--- a/monai/deploy/operators/dicom_seg_writer_operator.py
+++ b/monai/deploy/operators/dicom_seg_writer_operator.py
@@ -153,7 +153,7 @@ class DICOMSegmentationWriterOperator(Operator):
             self.create_dicom_seg(seg_image_numpy, dicom_series, output_path)
             break
 
-    def create_dicom_seg(self, image: Image, dicom_series: DICOMSeries, file_path: Path):
+    def create_dicom_seg(self, image: np.ndarray, dicom_series: DICOMSeries, file_path: Path):
         file_path.parent.absolute().mkdir(parents=True, exist_ok=True)
 
         dicom_dataset_list = [i.get_native_sop_instance() for i in dicom_series.get_sop_instances()]
@@ -550,7 +550,7 @@ def set_pixel_meta(dicomOutput, input_ds):
 
     dicomOutput.Rows = input_ds.Rows
     dicomOutput.Columns = input_ds.Columns
-    dicomOutput.BitsAllocated = 8  # add_new(0x00280100, 'US', 8) # Bits allocated
+    dicomOutput.BitsAllocated = 1  # add_new(0x00280100, 'US', 8) # Bits allocated
     dicomOutput.BitsStored = 1
     dicomOutput.HighBit = 0
     dicomOutput.PixelRepresentation = 0


### PR DESCRIPTION
Investigated this issue from multiple angles, but as often the case, an unexplainable change cause the issue:
-  In the original check-in on 08/24/2021 works (the core impl is based on existing working version). The Segmentation type is a binary seg, so Line 486: `dicomOutput.BitsAllocated = 1` 
- Later, on 09/17/2021, for unknown reason, bit allocated was changed, Line 524: `dicomOutput.BitsAllocated = 8`
- The fix is then simply reverting the bits allocated back to 1, testing the DICOM Seg Writer by itself, and then testing the applications that use the DICOM Seg Writer. The results were verified.
- Also noted that the DICOM Seg Writer can only support up to 8 segmentation labels, and this is the reason the UNETR example application fails to create DICOM Seg instance as it has upto 13 labels. Hence, removed the DICOM Seg creation from UNETR application and replaced it with STL writer with the setting to generate mesh for all detected segments.

An example of the DICOM Seg instance from the Spleen Seg application is shown below, opened with MicroDICOM

  
![image](https://user-images.githubusercontent.com/38891913/161898710-0f98357f-2d5b-4755-8a05-9de28d641bcb.png)

The screenshot of the display of STL of multiple organs segmented by the UNETR model/app. Note: STL does not have support for defining colors of the mesh.
![image](https://user-images.githubusercontent.com/38891913/161912517-219f9ef9-9e54-4364-92ff-061c7fd57fd9.png)
