### PR TITLE
Add support for VOI LUT in DICOMSeriesToVolumeOperator

### DIFF
--- a/monai/deploy/operators/dicom_series_to_volume_operator.py
+++ b/monai/deploy/operators/dicom_series_to_volume_operator.py
@@ -84,7 +84,7 @@ class DICOMSeriesToVolumeOperator(Operator):
         return study_selected_series_list[0].selected_series[0].image
 
     def generate_voxel_data(self, series):
-        """Applies rescale slope and rescale intercept to the pixels.
+        """Applies rescale operation and also VOI LUT to the pixels, if required.
 
         Args:
             series: DICOM Series for which the pixel data needs to be extracted.

--- a/monai/deploy/operators/dicom_series_to_volume_operator.py
+++ b/monai/deploy/operators/dicom_series_to_volume_operator.py
@@ -32,6 +32,15 @@ class DICOMSeriesToVolumeOperator(Operator):
     Channel is limited to 1 as of now, and `C` is absent in the NumPy array.
     """
 
+    def __init__(self, apply_voi_lut: bool = False, *args, **kwargs):
+         """Creates an instance of this class
+         Args:
+             apply_voi_lut (bool): If true, tries to apply VOI LUT to voxel data.
+                                   Defaults to False.
+         """
+         super().__init__(*args, **kwargs)
+         self._apply_voi_lut = apply_voi_lut
+
     def compute(self, op_input: InputContext, op_output: OutputContext, context: ExecutionContext):
         """Performs computation for this operator and handles I/O."""
 

--- a/monai/deploy/operators/dicom_series_to_volume_operator.py
+++ b/monai/deploy/operators/dicom_series_to_volume_operator.py
@@ -19,6 +19,8 @@ import monai.deploy.core as md
 from monai.deploy.core import ExecutionContext, Image, InputContext, IOType, Operator, OutputContext
 from monai.deploy.core.domain.dicom_series_selection import StudySelectedSeries
 
+from pydicom.pixel_data_handlers import util
+
 
 @md.input("study_selected_series_list", List[StudySelectedSeries], IOType.IN_MEMORY)
 @md.output("image", Image, IOType.IN_MEMORY)

--- a/monai/deploy/operators/dicom_series_to_volume_operator.py
+++ b/monai/deploy/operators/dicom_series_to_volume_operator.py
@@ -34,13 +34,13 @@ class DICOMSeriesToVolumeOperator(Operator):
     """
 
     def __init__(self, apply_voi_lut: bool = False, *args, **kwargs):
-         """Creates an instance of this class
-         Args:
-             apply_voi_lut (bool): If true, tries to apply VOI LUT to voxel data.
-                                   Defaults to False.
-         """
-         super().__init__(*args, **kwargs)
-         self._apply_voi_lut = apply_voi_lut
+        """Creates an instance of this class
+        Args:
+            apply_voi_lut (bool): If true, tries to apply VOI LUT to voxel data.
+                                  Defaults to False.
+        """
+        super().__init__(*args, **kwargs)
+        self._apply_voi_lut = apply_voi_lut
 
     def compute(self, op_input: InputContext, op_output: OutputContext, context: ExecutionContext):
         """Performs computation for this operator and handles I/O."""

--- a/monai/deploy/operators/dicom_series_to_volume_operator.py
+++ b/monai/deploy/operators/dicom_series_to_volume_operator.py
@@ -18,8 +18,9 @@ import numpy as np
 import monai.deploy.core as md
 from monai.deploy.core import ExecutionContext, Image, InputContext, IOType, Operator, OutputContext
 from monai.deploy.core.domain.dicom_series_selection import StudySelectedSeries
+from monai.deploy.utils.importutil import optional_import
 
-from pydicom.pixel_data_handlers import util
+util, _ = optional_import("pydicom.pixel_data_handlers", name="util")
 
 
 @md.input("study_selected_series_list", List[StudySelectedSeries], IOType.IN_MEMORY)


### PR DESCRIPTION
- introduces the class attribute `_apply_voi_lut`
  - defaults to `False` preserving backwards compatibility
- uses pydicom's pixel data handler utilities to apply rescale operations and VOI LUT
  - `apply_modality_lut()` for rescale operation (changes former implementation)
  - `apply_voi_lut()` for windowing operation (optional, depends on class attribute `_apply_voi_lut`)

Successfully tested with the changes of #290

Adapted from: https://github.com/pydicom/pydicom/issues/1125