### PR TITLE
Add debug message for App packager/runner command

### DIFF
--- a/monai/deploy/packager/util.py
+++ b/monai/deploy/packager/util.py
@@ -236,6 +236,8 @@ def build_image(args: dict, temp_dir: str):
         docker_build_cmd += " --no-cache"
     proc = subprocess.Popen(docker_build_cmd, stdout=subprocess.PIPE, shell=True)
 
+    logger.debug("Docker image build command: %s", docker_build_cmd)
+
     spinner = ProgressSpinner("Building MONAI Application Package... ")
     spinner.start()
 

--- a/monai/deploy/runner/runner.py
+++ b/monai/deploy/runner/runner.py
@@ -114,6 +114,7 @@ def run_app(map_name: str, input_path: Path, output_path: Path, app_info: dict, 
     # cmd += " -v {}:{} -v {}:{} {}".format(
     #     input_path.absolute(), map_input, output_path.absolute(), map_output, map_name
     # )
+    logger.debug("Executing command: %s", cmd)
 
     return run_cmd(cmd)
 


### PR DESCRIPTION
Add a simple change to log execution command when log level is `DEBUG`

```bash
monai-deploy package apps/simple_imaging_app -t simple_app:latest -l DEBUG         
```

```
[DEBUG] (app_packager) - Docker image build command: docker build -f "./monai_tmprxl05_xh/dockerfile" -t simple_app:latest "./monai_tmprxl05_xh" --build-arg MONAI_UID=$(id -u) --build-arg MONAI_GID=$(id -g)
```

```bash
monai-deploy run simple_app:latest input output output -l DEBUG           
```
```
...
Executing command: docker run --rm -a STDERR -a STDOUT -e MONAI_INPUTPATH="/var/monai/input" -e MONAI_OUTPUTPATH="/var/monai/output" -e MONAI_MODELPATH=/opt/monai/models -v "/home/gbae/repo/monai-deploy-app-sdk/examples/input":"/var/monai/input" -v "/home/gbae/repo/monai-deploy-app-sdk/examples/output":"/var/monai/output" --shm-size=1g --entrypoint "/bin/bash" "simple_app:latest" -c "python3 -u /opt/monai/app/app.py"
```

This would help debug App packager/runner issues.

Signed-off-by: Gigon Bae <gbae@nvidia.com>