### PR TITLE
Use optional import for nibabel and explicitly add dependencies to dev and example requirements files.

### DIFF
--- a/monai/deploy/operators/stl_conversion_operator.py
+++ b/monai/deploy/operators/stl_conversion_operator.py
@@ -16,11 +16,11 @@ import tempfile
 from pathlib import Path
 from typing import Dict, Optional
 
-import nibabel as nib
 import numpy as np
 
 from monai.deploy.utils.importutil import optional_import
 
+nib, _ = optional_import("nibabel")
 sitk, _ = optional_import("SimpleITK")
 label, _ = optional_import("skimage.measure", name="label")
 measure, _ = optional_import("skimage", name="measure")
@@ -36,7 +36,7 @@ __all__ = ["STLConversionOperator", "STLConverter"]
 
 @md.input("image", Image, IOType.IN_MEMORY)
 @md.output("stl_output", DataPath, IOType.DISK)
-@md.env(pip_packages=["numpy>=1.21", "numpy-stl>=2.12.0", "scikit-image>=0.17.2", "trimesh>=3.8.11"])
+@md.env(pip_packages=["numpy>=1.21", "nibabel >= 3.2.1", "numpy-stl>=2.12.0", "scikit-image>=0.17.2", "trimesh>=3.8.11"])
 class STLConversionOperator(Operator):
     """Converts volumetric image to surface mesh in STL format, file output only."""
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -29,3 +29,7 @@ pydicom>=1.4.2
 SimpleITK>=2.0.0
 Pillow>=8.0.0
 bump2version==1.0.1
+scikit-image >= 0.17.2
+nibabel >= 3.2.1
+numpy-stl >= 2.12.0
+trimesh >= 3.8.11

--- a/requirements-examples.txt
+++ b/requirements-examples.txt
@@ -3,3 +3,5 @@ pydicom >= 1.4.2
 SimpleITK >= 2.0.0
 Pillow >= 8.0.0
 nibabel >= 3.2.1
+numpy-stl >= 2.12.0
+trimesh >= 3.8.11


### PR DESCRIPTION
Per reported issue #302, the mednist MAP fails because of missing nibabel package, all because of the non-"optional import" for it in the stl_conversion_operator.py.

The mednist application does not use STLConversionOperator, whose dependencies are therefore not picked up by the App's info gathering through the env decorator. Not setting optional import then causes missing package issues when the not satisfied package is not set as optional import.  

Signed-off-by: mmelqin <mingmelvinq@nvidia.com>