### PR TITLE
Add the newly introduced example to readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ YouTube Video:
 
 ### [5) Building and deploying Segmentation app with MONAI Inference Service (MIS)](https://docs.monai.io/projects/monai-deploy-app-sdk/en/latest/getting_started/tutorials/05_full_tutorial.html)
 
+### [6) Creating a Segmentation app consuming a MONAI Bundle](https://docs.monai.io/projects/monai-deploy-app-sdk/en/0.4.0/getting_started/tutorials/06_monai_bundle_app.html)
+
 ### [Examples](https://docs.monai.io/projects/monai-deploy-app-sdk/en/latest/getting_started/examples.html)
 
 <https://github.com/Project-MONAI/monai-deploy-app-sdk/tree/main/examples/apps> has example apps that you can see.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ monai-deploy run simple_app:latest input output
 
 ### [Tutorials](https://docs.monai.io/projects/monai-deploy-app-sdk/en/latest/getting_started/tutorials/index.html)
 
+Tutorials are provided to help getting started with the App SDK, to name but a few below.
+
 #### [1) Creating a simple image processing app](https://docs.monai.io/projects/monai-deploy-app-sdk/en/latest/getting_started/tutorials/01_simple_app.html)
 
 #### [2) Creating MedNIST Classifier app](https://docs.monai.io/projects/monai-deploy-app-sdk/en/latest/getting_started/tutorials/02_mednist_app.html)


### PR DESCRIPTION
This is a a bit of a chicken-and-egg problem, since the readme.md refers
to the published latest version of the doc which can only happen when
the release build is done, and this particular doc is part of the build,
included in the package to be pushed to pypi.org.

Next time, need to consider add the entry, with a placeholder/non-existent
URL prior to the release build, so that the content will show up in the new
package, and URL leads to valid content post build.

Signed-off-by: mmelqin <mingmelvinq@nvidia.com>