### PR TITLE
Add highdicom license to the Third Party Notices

### DIFF
--- a/THIRD_PARTY_NOTICES/highdicom_MIT_LICENSE.txt
+++ b/THIRD_PARTY_NOTICES/highdicom_MIT_LICENSE.txt
@@ -1,0 +1,24 @@
+highdicom is licensed under the MIT License: http://www.opensource.org/licenses/mit-license.php
+
+A short and simple permissive license with conditions only requiring preservation of copyright and license notices. Licensed works, modifications, and larger works may be distributed under different terms and without source code.
+
+
+Copyright 2020 MGH Computational Pathology
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.


### PR DESCRIPTION
The App SDK acknowledges 3rd party dependencies by listing their published license files in the Third Party Notices folder, so that the users of the App SDK can ensure the legality of adopting App SDK for intended uses.
  
Signed-off-by: mmelqin <mingmelvinq@nvidia.com>