### PR TITLE
Fix the setting of init state in its own PR, instead of rolled into others

### DIFF
--- a/monai/deploy/operators/monai_bundle_inference_operator.py
+++ b/monai/deploy/operators/monai_bundle_inference_operator.py
@@ -460,7 +460,7 @@ class MonaiBundleInferenceOperator(InferenceOperator):
                     if not self._init_completed:
                         self._bundle_path = self._model_network.path
                         self._init_config(self._bundle_config_names.config_names)
-                        self._init_completed
+                        self._init_completed = True
         elif self._bundle_path:
             # For the case of local dev/testing when the bundle path is not passed in as an exec cmd arg.
             # When run as a MAP docker, the bundle file is expected to be in the context, even if the model


### PR DESCRIPTION
Per discussion in issue/bug #326 , this PR is to fix the missing value on setting the init state. The impact to the app execution is minimal, if any, in the example apps.

Signed-off-by: mmelqin <mingmelvinq@nvidia.com>