### PR TITLE
Added support of matching instance level tags, and update liver seg

### DIFF
--- a/examples/apps/ai_livertumor_seg_app/app.py
+++ b/examples/apps/ai_livertumor_seg_app/app.py
@@ -21,7 +21,6 @@ from monai.deploy.operators.dicom_data_loader_operator import DICOMDataLoaderOpe
 from monai.deploy.operators.dicom_seg_writer_operator import DICOMSegmentationWriterOperator, SegmentDescription
 from monai.deploy.operators.dicom_series_selector_operator import DICOMSeriesSelectorOperator
 from monai.deploy.operators.dicom_series_to_volume_operator import DICOMSeriesToVolumeOperator
-
 from monai.deploy.operators.publisher_operator import PublisherOperator
 
 # This is a sample series selection rule in JSON, simply selecting CT series.

--- a/examples/apps/ai_livertumor_seg_app/app.py
+++ b/examples/apps/ai_livertumor_seg_app/app.py
@@ -22,7 +22,7 @@ from monai.deploy.operators.dicom_seg_writer_operator import DICOMSegmentationWr
 from monai.deploy.operators.dicom_series_selector_operator import DICOMSeriesSelectorOperator
 from monai.deploy.operators.dicom_series_to_volume_operator import DICOMSeriesToVolumeOperator
 
-# from monai.deploy.operators.publisher_operator import PublisherOperator
+from monai.deploy.operators.publisher_operator import PublisherOperator
 
 # This is a sample series selection rule in JSON, simply selecting CT series.
 # If the study has more than 1 CT series, then all of them will be selected.
@@ -74,7 +74,7 @@ class AILiverTumorApp(Application):
         liver_tumor_seg_op = LiverTumorSegOperator()
 
         # Create the publisher operator
-        # publisher_op = PublisherOperator()
+        publisher_op = PublisherOperator()
 
         # Create DICOM Seg writer providing the required segment description for each segment with
         # the actual algorithm and the pertinent organ/tissue.
@@ -116,7 +116,7 @@ class AILiverTumorApp(Application):
         self.add_flow(series_to_vol_op, liver_tumor_seg_op, {"image": "image"})
         # Add the publishing operator to save the input and seg images for Render Server.
         # Note the PublisherOperator has temp impl till a proper rendering module is created.
-        # self.add_flow(liver_tumor_seg_op, publisher_op, {"saved_images_folder": "saved_images_folder"})
+        self.add_flow(liver_tumor_seg_op, publisher_op, {"saved_images_folder": "saved_images_folder"})
         # Note below the dicom_seg_writer requires two inputs, each coming from a source operator.
         self.add_flow(
             series_selector_op, dicom_seg_writer, {"study_selected_series_list": "study_selected_series_list"}

--- a/examples/apps/ai_livertumor_seg_app/livertumor_seg_operator.py
+++ b/examples/apps/ai_livertumor_seg_app/livertumor_seg_operator.py
@@ -34,7 +34,7 @@ from monai.transforms import (
 @md.input("image", Image, IOType.IN_MEMORY)
 @md.output("seg_image", Image, IOType.IN_MEMORY)
 @md.output("saved_images_folder", DataPath, IOType.DISK)
-@md.env(pip_packages=["monai>=0.8.1", "torch>=1.5", "numpy>=1.21", "nibabel"])
+@md.env(pip_packages=["monai==0.9.0", "torch>=1.5", "numpy>=1.21", "nibabel"])
 class LiverTumorSegOperator(Operator):
     """Performs liver and tumor segmentation using a DL model with an image converted from a DICOM CT series.
 

--- a/monai/deploy/operators/dicom_series_selector_operator.py
+++ b/monai/deploy/operators/dicom_series_selector_operator.py
@@ -228,7 +228,7 @@ class DICOMSeriesSelectorOperator(Operator):
                         attr_value = [series.get_sop_instances()[0].get_native_sop_instance()[key].repval]
                         series_attr.update({key: attr_value})
                     except Exception:
-                        logging.info(f"        Attribute {key} not at instance leve either.")
+                        logging.info(f"        Attribute {key} not at instance level either.")
 
                 if not attr_value:
                     matched = False

--- a/monai/deploy/operators/dicom_series_selector_operator.py
+++ b/monai/deploy/operators/dicom_series_selector_operator.py
@@ -219,7 +219,17 @@ class DICOMSeriesSelectorOperator(Operator):
                     continue
                 # Try getting the attribute value from Study and current Series prop dict
                 attr_value = series_attr.get(key, None)
-                logging.info(f"    Series attribute value: {attr_value}")
+                logging.info(f"    Series attribute {key} value: {attr_value}")
+
+                # If not found, try the best at the native instance level for string VR
+                # This is mainly for attributes like ImageType
+                if not attr_value:
+                    try:
+                        attr_value = [series.get_sop_instances()[0].get_native_sop_instance()[key].repval]
+                        series_attr.update({key: attr_value})
+                    except Exception:
+                        logging.info(f"        Attribute {key} not at instance leve either.")
+
                 if not attr_value:
                     matched = False
                 elif isinstance(attr_value, numbers.Number):
@@ -233,12 +243,13 @@ class DICOMSeriesSelectorOperator(Operator):
                         if re.search(value_to_match, attr_value, re.IGNORECASE):
                             matched = True
                 elif isinstance(attr_value, list):
-                    meta_data_set = {str(element).lower() for element in attr_value}
+                    # Assume multi value string attributes
+                    meta_data_list = str(attr_value).lower()
                     if isinstance(value_to_match, list):
                         value_set = {str(element).lower() for element in value_to_match}
-                        matched = all(val in meta_data_set for val in value_set)
+                        matched = all(val in meta_data_list for val in value_set)
                     elif isinstance(value_to_match, (str, numbers.Number)):
-                        matched = str(value_to_match).lower() in meta_data_set
+                        matched = str(value_to_match).lower() in meta_data_list
                 else:
                     raise NotImplementedError(f"Not support for matching on this type: {type(value_to_match)}")
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,8 @@ max_line_length = 120
 ignore =
     E203,E305,E402,E501,E721,E741,F821,F841,F999,W503,W504,C408,E302,W291,E303,
     # N812 lowercase 'torch.nn.functional' imported as non lowercase 'F'
-    N812
+    N812,
+    B024 #abstract base class, but it has no abstract methods
 per_file_ignores =
     __init__.py: F401
     # Allow using camel case for variable/argument names for the sake of readability.


### PR DESCRIPTION
Existing series selection implementation supports matching attributes at down to series level, however, sometimes key instance level attributes can help narrow down the selection, e.g. `Photometric Interpretation`.

Also updated the example app for make use of the updated selector, as well as pinning the monai dependency at 0.9.0 for now.
   
Signed-off-by: M Q <mingmelvinq@nvidia.com>