### PR TITLE
Add DICOM PDF Writer and split dicom_utils common module out of Text SR Writer

### DIFF
--- a/THIRD_PARTY_NOTICES/PyPDF2_BSD-3_LICENSE.txt
+++ b/THIRD_PARTY_NOTICES/PyPDF2_BSD-3_LICENSE.txt
@@ -1,0 +1,29 @@
+Copyright (c) 2006-2008, Mathieu Fenniak
+Some contributions copyright (c) 2007, Ashish Kulkarni <kulkarni.ashish@gmail.com>
+Some contributions copyright (c) 2014, Steve Witham <switham_github@mac-guyver.com>
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+* The name of the author may not be used to endorse or promote products
+derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/examples/apps/mednist_classifier_monaideploy/mednist_classifier_monaideploy.py
+++ b/examples/apps/mednist_classifier_monaideploy/mednist_classifier_monaideploy.py
@@ -22,7 +22,7 @@ from monai.deploy.core import (
     Operator,
     OutputContext,
 )
-from monai.deploy.operators.dicom_text_sr_writer_operator import DICOMTextSRWriterOperator, EquipmentInfo, ModelInfo
+from monai.deploy.operators import DICOMTextSRWriterOperator, EquipmentInfo, ModelInfo
 from monai.transforms import AddChannel, Compose, EnsureType, ScaleIntensity
 
 MEDNIST_CLASSES = ["AbdomenCT", "BreastMRI", "CXR", "ChestCT", "Hand", "HeadCT"]

--- a/monai/deploy/operators/__init__.py
+++ b/monai/deploy/operators/__init__.py
@@ -19,8 +19,10 @@
     DICOMSeriesSelectorOperator
     DICOMSeriesToVolumeOperator
     DICOMTextSRWriterOperator
+    EquipmentInfo
     InferenceOperator
     IOMapping
+    ModelInfo
     MonaiBundleInferenceOperator
     MonaiSegInferenceOperator
     PNGConverterOperator
@@ -29,12 +31,13 @@
     STLConverter
 """
 
+from .dicom_utils import EquipmentInfo, ModelInfo, random_with_n_digits, save_dcm_file, write_common_modules
 from .clara_viz_operator import ClaraVizOperator
 from .dicom_data_loader_operator import DICOMDataLoaderOperator
 from .dicom_seg_writer_operator import DICOMSegmentationWriterOperator
 from .dicom_series_selector_operator import DICOMSeriesSelectorOperator
 from .dicom_series_to_volume_operator import DICOMSeriesToVolumeOperator
-from .dicom_text_sr_writer_operator import DICOMTextSRWriterOperator, EquipmentInfo, ModelInfo
+from .dicom_text_sr_writer_operator import DICOMTextSRWriterOperator
 from .inference_operator import InferenceOperator
 from .monai_bundle_inference_operator import BundleConfigNames, IOMapping, MonaiBundleInferenceOperator
 from .monai_seg_inference_operator import MonaiSegInferenceOperator

--- a/monai/deploy/operators/__init__.py
+++ b/monai/deploy/operators/__init__.py
@@ -31,13 +31,13 @@
     STLConverter
 """
 
-from .dicom_utils import EquipmentInfo, ModelInfo, random_with_n_digits, save_dcm_file, write_common_modules
 from .clara_viz_operator import ClaraVizOperator
 from .dicom_data_loader_operator import DICOMDataLoaderOperator
 from .dicom_seg_writer_operator import DICOMSegmentationWriterOperator
 from .dicom_series_selector_operator import DICOMSeriesSelectorOperator
 from .dicom_series_to_volume_operator import DICOMSeriesToVolumeOperator
 from .dicom_text_sr_writer_operator import DICOMTextSRWriterOperator
+from .dicom_utils import EquipmentInfo, ModelInfo, random_with_n_digits, save_dcm_file, write_common_modules
 from .inference_operator import InferenceOperator
 from .monai_bundle_inference_operator import BundleConfigNames, IOMapping, MonaiBundleInferenceOperator
 from .monai_seg_inference_operator import MonaiSegInferenceOperator

--- a/monai/deploy/operators/dicom_encapsulated_pdf_writer_operator.py
+++ b/monai/deploy/operators/dicom_encapsulated_pdf_writer_operator.py
@@ -116,7 +116,7 @@ class DICOMEncapsulatedPDFWriterOperator(Operator):
         # Gets the input, prepares the output folder, and then delegates the processing.
         pdf_bytes: bytes = b""
         try:
-            pdf_bytes = (op_input.get("pdf_bytes"))
+            pdf_bytes = op_input.get("pdf_bytes")
         except ItemNotExistsError:
             try:
                 file_path = op_input.get("pdf_file")

--- a/monai/deploy/operators/dicom_encapsulated_pdf_writer_operator.py
+++ b/monai/deploy/operators/dicom_encapsulated_pdf_writer_operator.py
@@ -114,9 +114,9 @@ class DICOMEncapsulatedPDFWriterOperator(Operator):
         """
 
         # Gets the input, prepares the output folder, and then delegates the processing.
-        pdf_bytes = ""
+        pdf_bytes: bytes = b""
         try:
-            pdf_bytes = bytes(op_input.get("pdf_bytes")).strip()
+            pdf_bytes = (op_input.get("pdf_bytes"))
         except ItemNotExistsError:
             try:
                 file_path = op_input.get("pdf_file")
@@ -126,7 +126,7 @@ class DICOMEncapsulatedPDFWriterOperator(Operator):
             with open(file_path.path, "rb") as f:
                 pdf_bytes = f.read().strip()
 
-        if not pdf_bytes or not len(pdf_bytes):
+        if not pdf_bytes or not len(pdf_bytes.strip()):
             raise IOError("Input is read but blank.")
 
         try:

--- a/monai/deploy/operators/dicom_encapsulated_pdf_writer_operator.py
+++ b/monai/deploy/operators/dicom_encapsulated_pdf_writer_operator.py
@@ -1,4 +1,4 @@
-# Copyright 2021 MONAI Consortium
+# Copyright 2022 MONAI Consortium
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -9,13 +9,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import datetime
+from ast import Bytes
+from io import BytesIO
 import logging
 from pathlib import Path
-from random import randint
-from typing import Dict, List, Optional, Text, Union
+from PyPDF2 import PdfReader
+from typing import Dict, List, Optional, Union
 
 from monai.deploy.utils.importutil import optional_import
+
 
 dcmread, _ = optional_import("pydicom", name="dcmread")
 dcmwrite, _ = optional_import("pydicom.filewriter", name="dcmwrite")
@@ -36,14 +38,13 @@ from .dicom_utils import EquipmentInfo, ModelInfo, save_dcm_file, write_common_m
 
 
 # The SR writer operator class
-@md.input("classification_result", Text, IOType.IN_MEMORY)
-@md.input("classification_result_file", DataPath, IOType.DISK)
+@md.input("pdf_bytes", Bytes, IOType.IN_MEMORY)
+@md.input("pdf_file", DataPath, IOType.DISK)
 @md.input("study_selected_series_list", List[StudySelectedSeries], IOType.IN_MEMORY)
 @md.output("dicom_instance", DataPath, IOType.DISK)
 @md.env(pip_packages=["pydicom >= 1.4.2"])
-class DICOMTextSRWriterOperator(Operator):
+class DICOMEncapsulatedPDFWriterOperator(Operator):
 
-    # File extension for the generated DICOM Part 10 file.
     DCM_EXTENSION = ".dcm"
 
     def __init__(
@@ -55,19 +56,19 @@ class DICOMTextSRWriterOperator(Operator):
         *args,
         **kwargs,
     ):
-        """Class to write DICOM SR SOP Instance for AI textual result in memory or in a file.
+        """Class to write DICOM Encapsulated PDF Instance with PDF bytes in memory or in a file.
 
         Args:
             copy_tags (bool): True for copying DICOM attributes from a provided DICOMSeries.
             model_info (ModelInfo): Object encapsulating model creator, name, version and UID.
             equipment_info (EquipmentInfo, optional): Object encapsulating info for DICOM Equipment Module.
                                                       Defaults to None.
-            custom_tags (Dict[str, str], optional): Dictionary for setting custom DICOM tags using Keywords and str values only.
-                                                    Defaults to None.
+            custom_tags (Dict[str, str], optional): Dictionary for setting custom DICOM tags using Keywords
+                                                    and str values only. Defaults to None.
 
         Raises:
             ValueError: If copy_tags is true and no DICOMSeries object provided, or
-                        if result cannot be found either in memory or from file.
+                        if PDF bytes cannot be found in memory or loaded from the file.
         """
         super().__init__(*args, **kwargs)
         self._logger = logging.getLogger("{}.{}".format(__name__, type(self).__name__))
@@ -78,15 +79,17 @@ class DICOMTextSRWriterOperator(Operator):
 
         # Set own Modality and SOP Class UID
         # Modality, e.g.,
-        #   "OT" for PDF
+        #   "OT" for PDF, "DOC" would do too.
         #   "SR" for Structured Report.
         # Media Storage SOP Class UID, e.g.,
         #   "1.2.840.10008.5.1.4.1.1.88.11" for Basic Text SR Storage
         #   "1.2.840.10008.5.1.4.1.1.104.1" for Encapsulated PDF Storage,
         #   "1.2.840.10008.5.1.4.1.1.88.34" for Comprehensive 3D SR IOD
         #   "1.2.840.10008.5.1.4.1.1.66.4" for Segmentation Storage
-        self.modality_type = "SR"
-        self.sop_class_uid = "1.2.840.10008.5.1.4.1.1.88.11"
+        #   '1.2.840.10008.5.1.4.1.1.104.1' for Encapsulated PDF Storage
+        self.modality_type = 'OT'
+        self.sop_class_uid = '1.2.840.10008.5.1.4.1.1.104.1'
+
         # Equipment version may be different from contributing equipment version
         try:
             self.software_version_number = get_sdk_semver()  # SDK Version
@@ -97,33 +100,33 @@ class DICOMTextSRWriterOperator(Operator):
     def compute(self, op_input: InputContext, op_output: OutputContext, context: ExecutionContext):
         """Performs computation for this operator and handles I/O.
 
-        For now, only a single result content is supported, which could be in memory or an accessible file.
-        The DICOM series used during inference is optional, but is required if the
+        For now, only a single result content is supported, which could be in bytes or a path
+        to the PDF file. The DICOM series used during inference is optional, but is required if the
         `copy_tags` is true indicating the generated DICOM object needs to copy study level metadata.
 
         When there are multiple selected series in the input, the first series' containing study will
         be used for retrieving DICOM Study module attributes, e.g. StudyInstanceUID.
 
         Raises:
-            FileNotFoundError: When result object not in the input, and result file not found either.
-            ValueError: Content object and file path not in the inputs, or no DICOM series when required.
-            IOError: If the input content is blank.
+            FileNotFoundError: When bytes are not in the input, and the file is not given or found.
+            ValueError: Input bytes and PDF file not in the input, or no DICOM series when required.
+            IOError: If fails to get the bytes of the PDF
         """
 
         # Gets the input, prepares the output folder, and then delegates the processing.
-        result_text = ""
+        pdf_bytes = ""
         try:
-            result_text = str(op_input.get("classification_result")).strip()
+            pdf_bytes = bytes(op_input.get("pdf_bytes")).strip()
         except ItemNotExistsError:
             try:
-                file_path = op_input.get("classification_result_file")
+                file_path = op_input.get("pdf_file")
             except ItemNotExistsError:
-                raise ValueError("None of the named inputs for result can be found.") from None
+                raise ValueError("None of the named inputs can be found.") from None
             # Read file, and if exception, let it bubble up
-            with open(file_path.path, "r") as f:
-                result_text = f.read().strip()
+            with open(file_path.path, "rb") as f:
+                pdf_bytes = f.read().strip()
 
-        if not result_text:
+        if not pdf_bytes or not len(pdf_bytes):
             raise IOError("Input is read but blank.")
 
         try:
@@ -133,7 +136,7 @@ class DICOMTextSRWriterOperator(Operator):
 
         dicom_series = None  # It can be None if not to copy_tags.
         if self.copy_tags:
-            # Get the first DICOM Series to retrieve study level tags.
+            # Get the first DICOM Series for retrieving study level tags.
             if not study_selected_series_list or len(study_selected_series_list) < 1:
                 raise ValueError("Missing input, list of 'StudySelectedSeries'.")
             for study_selected_series in study_selected_series_list:
@@ -147,23 +150,25 @@ class DICOMTextSRWriterOperator(Operator):
         output_dir.mkdir(parents=True, exist_ok=True)
 
         # Now ready to starting writing the DICOM instance
-        self.write(result_text, dicom_series, output_dir)
+        self.write(pdf_bytes, dicom_series, output_dir)
 
-    def write(self, content_text, dicom_series: Optional[DICOMSeries], output_dir: Path):
+    def write(self, content_bytes, dicom_series: Optional[DICOMSeries], output_dir: Path):
         """Writes DICOM object
 
         Args:
-            content_file (str): file containing the contents
+            content_bytes (bytes): Content bytes of PDF
             dicom_series (DicomSeries): DicomSeries object encapsulating the original series.
-            model_info (MoelInfo): Object encapsulating model creator, name, version and UID.
-
-        Returns:
-            PyDicom Dataset
+            output_dir (Path): Folder path for saving the generated file.
         """
         self._logger.debug("Writing DICOM object...\n")
 
-        if not content_text or not len(content_text.strip()):
+        if not isinstance(content_bytes, bytes):
+            raise ValueError("Input must be bytes.")
+        elif not len(content_bytes.strip()):
             raise ValueError("Content is empty.")
+        elif not self._is_pdf_bytes(content_bytes):
+            raise ValueError("Not PDF bytes.")
+
         if not isinstance(output_dir, Path):
             raise ValueError("output_dir is not a valid Path.")
 
@@ -173,57 +178,27 @@ class DICOMTextSRWriterOperator(Operator):
             dicom_series, self.copy_tags, self.modality_type, self.sop_class_uid, self.model_info, self.equipment_info
         )
 
-        # SR specific
-        ds.VerificationFlag = "UNVERIFIED"  # Not attested by a legally accountable person.
+        # Encapsulated PDF specific
+        # SC Equipment Module
+        ds.Modality = self.modality_type
+        ds.ConversionType = u'SD'    # Describes the kind of image conversion, Scanned Doc
 
-        # Per recommendation of IHE Radiology Technical Framework Supplement
-        # AI Results (AIR) Rev1.1 - Trial Implementation
-        # Specifically for Qualitative Findings,
-        # Qualitative findings shall be encoded in an instance of the DICOM Comprehensive 3D SR SOP
-        # Class using TID 1500 (Measurement Report) as the root template.
-        # DICOM PS3.16: TID 1500 Measurement Report
-        # http://dicom.nema.org/medical/dicom/current/output/chtml/part16/chapter_A.html#sect_TID_1500
-        # The value for Procedure Reported (121058, DCM, "Procedure reported") shall describe the
-        # imaging procedure analyzed, not the algorithm used.
+        # Encapsulated Document Module
+        ds.VerificationFlag = u'UNVERIFIED'    # Not attested by a legally accountable person.
 
-        # Use text value for example
-        ds.ValueType = "CONTAINER"
+        ds.BurnedInAnnotation = u'YES'
+        ds.DocumentTitle = u'Generated Observations'
+        ds.MIMETypeOfEncapsulatedDocument = u'application/pdf'
+        ds.EncapsulatedDocument = content_bytes
 
-        # ConceptNameCode Sequence
+        ## ConceptNameCode Sequence
         seq_concept_name_code = Sequence()
-        ds.ConceptNameCodeSequence = seq_concept_name_code
-
-        # Concept Name Code Sequence: Concept Name Code
         ds_concept_name_code = Dataset()
-        ds_concept_name_code.CodeValue = "18748-4"
-        ds_concept_name_code.CodingSchemeDesignator = "LN"
-        ds_concept_name_code.CodeMeaning = "Diagnostic Imaging Report"
+        ds_concept_name_code.CodeValue = u'18748-4'
+        ds_concept_name_code.CodingSchemeDesignator = u'LN'
+        ds_concept_name_code.CodeMeaning = u'Diagnostic Imaging Report'
         seq_concept_name_code.append(ds_concept_name_code)
-
-        ds.ContinuityOfContent = "SEPARATE"
-
-        # Content Sequence
-        content_sequence = Sequence()
-        ds.ContentSequence = content_sequence
-
-        # Content Sequence: Content 1
-        content1 = Dataset()
-        content1.RelationshipType = "CONTAINS"
-        content1.ValueType = "TEXT"
-
-        # Concept Name Code Sequence
-        concept_name_code_sequence = Sequence()
-        content1.ConceptNameCodeSequence = concept_name_code_sequence
-
-        # Concept Name Code Sequence: Concept Name Code 1
-        concept_name_code1 = Dataset()
-        concept_name_code1.CodeValue = "111412"  # or 111413 "Overall Assessment"
-        concept_name_code1.CodingSchemeDesignator = "DCM"
-        concept_name_code1.CodeMeaning = "Narrative Summary"  # or 111413 'Overall Assessment'
-        concept_name_code_sequence.append(concept_name_code1)
-
-        content1.TextValue = content_text  # The actual report content text
-        content_sequence.append(content1)
+        ds.ConceptNameCodeSequence = seq_concept_name_code
 
         # For now, only allow str Keywords and str value
         if self.custom_tags:
@@ -236,8 +211,19 @@ class DICOMTextSRWriterOperator(Operator):
                         logging.warning(f"Tag {k} was not written, due to {ex}")
 
         # Instance file name is the same as the new SOP instance UID
-        file_path = output_dir.joinpath(f"{ds.SOPInstanceUID}{DICOMTextSRWriterOperator.DCM_EXTENSION}")
+        file_path = output_dir.joinpath(f"{ds.SOPInstanceUID}{DICOMEncapsulatedPDFWriterOperator.DCM_EXTENSION}")
         save_dcm_file(ds, file_path)
+
+
+    def _is_pdf_bytes(self, content: bytes):
+        try:
+            bytes_stream = BytesIO(content)
+            reader = PdfReader(bytes_stream)
+            self._logger.debug(f"The PDF has {reader.pages} page(s).")
+        except Exception as ex:
+            self._logger.exception(f"Cannot read as PDF: {ex}")
+            return False
+        return True
 
 
 def test():
@@ -245,24 +231,25 @@ def test():
     from monai.deploy.operators.dicom_series_selector_operator import DICOMSeriesSelectorOperator
 
     current_file_dir = Path(__file__).parent.resolve()
-    data_path = current_file_dir.joinpath("../../../inputs/livertumor_ct/dcm/1-CT_series_liver_tumor_from_nii014")
-    out_path = "output_sr_op"
-    test_report_text = "Tumors detected in Liver using MONAI Liver Tumor Seg model."
-    test_copy_tags = True
+    dcm_folder = current_file_dir.joinpath("../../../inputs/livertumor_ct/dcm/1-CT_series_liver_tumor_from_nii014")
+    pdf_file = current_file_dir.joinpath("../../../inputs/pdf/TestPDF.pdf")
+    out_path = "output_pdf_op"
+    pdf_bytes = b"Not PDF bytes."
+    test_copy_tags = False
 
     loader = DICOMDataLoaderOperator()
     series_selector = DICOMSeriesSelectorOperator()
-    sr_writer = DICOMTextSRWriterOperator(
+    sr_writer = DICOMEncapsulatedPDFWriterOperator(
         copy_tags=test_copy_tags,
         model_info=None,
         equipment_info=EquipmentInfo(),
-        custom_tags={"SeriesDescription": "Textual report from AI algorithm. Not for clinical use."},
+        custom_tags={"SeriesDescription": "Report from AI algorithm. Not for clinical use."},
     )
 
     # Testing with the main entry functions
     dicom_series = None
     if test_copy_tags:
-        study_list = loader.load_data_to_studies(Path(data_path).absolute())
+        study_list = loader.load_data_to_studies(Path(dcm_folder).absolute())
         study_selected_series_list = series_selector.filter(None, study_list)
         # Get the first DICOM Series, as for now, only expecting this.
         if not study_selected_series_list or len(study_selected_series_list) < 1:
@@ -275,7 +262,10 @@ def test():
                 dicom_series = selected_series.series
                 print(type(dicom_series))
 
-    sr_writer.write(test_report_text, dicom_series, Path(out_path).absolute())
+    with open(pdf_file, "rb") as f:
+        pdf_bytes = f.read()
+
+    sr_writer.write(pdf_bytes, dicom_series, Path(out_path).absolute())
 
 
 if __name__ == "__main__":

--- a/monai/deploy/operators/dicom_encapsulated_pdf_writer_operator.py
+++ b/monai/deploy/operators/dicom_encapsulated_pdf_writer_operator.py
@@ -32,9 +32,8 @@ from monai.deploy.core import DataPath, ExecutionContext, InputContext, IOType, 
 from monai.deploy.core.domain.dicom_series import DICOMSeries
 from monai.deploy.core.domain.dicom_series_selection import StudySelectedSeries
 from monai.deploy.exceptions import ItemNotExistsError
+from monai.deploy.operators.dicom_utils import EquipmentInfo, ModelInfo, save_dcm_file, write_common_modules
 from monai.deploy.utils.version import get_sdk_semver
-
-from .dicom_utils import EquipmentInfo, ModelInfo, save_dcm_file, write_common_modules
 
 
 # The SR writer operator class
@@ -213,6 +212,7 @@ class DICOMEncapsulatedPDFWriterOperator(Operator):
         # Instance file name is the same as the new SOP instance UID
         file_path = output_dir.joinpath(f"{ds.SOPInstanceUID}{DICOMEncapsulatedPDFWriterOperator.DCM_EXTENSION}")
         save_dcm_file(ds, file_path)
+        self._logger.info(f"DICOM SOP instance saved in {file_path}")
 
     def _is_pdf_bytes(self, content: bytes):
         try:

--- a/monai/deploy/operators/dicom_encapsulated_pdf_writer_operator.py
+++ b/monai/deploy/operators/dicom_encapsulated_pdf_writer_operator.py
@@ -9,15 +9,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from ast import Bytes
 from io import BytesIO
-import logging
 from pathlib import Path
-from PyPDF2 import PdfReader
 from typing import Dict, List, Optional, Union
 
-from monai.deploy.utils.importutil import optional_import
+from PyPDF2 import PdfReader
 
+from monai.deploy.utils.importutil import optional_import
 
 dcmread, _ = optional_import("pydicom", name="dcmread")
 dcmwrite, _ = optional_import("pydicom.filewriter", name="dcmwrite")
@@ -87,8 +87,8 @@ class DICOMEncapsulatedPDFWriterOperator(Operator):
         #   "1.2.840.10008.5.1.4.1.1.88.34" for Comprehensive 3D SR IOD
         #   "1.2.840.10008.5.1.4.1.1.66.4" for Segmentation Storage
         #   '1.2.840.10008.5.1.4.1.1.104.1' for Encapsulated PDF Storage
-        self.modality_type = 'OT'
-        self.sop_class_uid = '1.2.840.10008.5.1.4.1.1.104.1'
+        self.modality_type = "OT"
+        self.sop_class_uid = "1.2.840.10008.5.1.4.1.1.104.1"
 
         # Equipment version may be different from contributing equipment version
         try:
@@ -181,22 +181,22 @@ class DICOMEncapsulatedPDFWriterOperator(Operator):
         # Encapsulated PDF specific
         # SC Equipment Module
         ds.Modality = self.modality_type
-        ds.ConversionType = u'SD'    # Describes the kind of image conversion, Scanned Doc
+        ds.ConversionType = "SD"  # Describes the kind of image conversion, Scanned Doc
 
         # Encapsulated Document Module
-        ds.VerificationFlag = u'UNVERIFIED'    # Not attested by a legally accountable person.
+        ds.VerificationFlag = "UNVERIFIED"  # Not attested by a legally accountable person.
 
-        ds.BurnedInAnnotation = u'YES'
-        ds.DocumentTitle = u'Generated Observations'
-        ds.MIMETypeOfEncapsulatedDocument = u'application/pdf'
+        ds.BurnedInAnnotation = "YES"
+        ds.DocumentTitle = "Generated Observations"
+        ds.MIMETypeOfEncapsulatedDocument = "application/pdf"
         ds.EncapsulatedDocument = content_bytes
 
         ## ConceptNameCode Sequence
         seq_concept_name_code = Sequence()
         ds_concept_name_code = Dataset()
-        ds_concept_name_code.CodeValue = u'18748-4'
-        ds_concept_name_code.CodingSchemeDesignator = u'LN'
-        ds_concept_name_code.CodeMeaning = u'Diagnostic Imaging Report'
+        ds_concept_name_code.CodeValue = "18748-4"
+        ds_concept_name_code.CodingSchemeDesignator = "LN"
+        ds_concept_name_code.CodeMeaning = "Diagnostic Imaging Report"
         seq_concept_name_code.append(ds_concept_name_code)
         ds.ConceptNameCodeSequence = seq_concept_name_code
 
@@ -213,7 +213,6 @@ class DICOMEncapsulatedPDFWriterOperator(Operator):
         # Instance file name is the same as the new SOP instance UID
         file_path = output_dir.joinpath(f"{ds.SOPInstanceUID}{DICOMEncapsulatedPDFWriterOperator.DCM_EXTENSION}")
         save_dcm_file(ds, file_path)
-
 
     def _is_pdf_bytes(self, content: bytes):
         try:

--- a/monai/deploy/operators/dicom_encapsulated_pdf_writer_operator.py
+++ b/monai/deploy/operators/dicom_encapsulated_pdf_writer_operator.py
@@ -50,8 +50,8 @@ class DICOMEncapsulatedPDFWriterOperator(Operator):
         self,
         copy_tags: bool,
         model_info: ModelInfo,
-        equipment_info: Union[EquipmentInfo, None] = None,
-        custom_tags: Union[Dict[str, str], None] = None,
+        equipment_info: Optional[EquipmentInfo] = None,
+        custom_tags: Optional[Dict[str, str]] = None,
         *args,
         **kwargs,
     ):

--- a/monai/deploy/operators/dicom_encapsulated_pdf_writer_operator.py
+++ b/monai/deploy/operators/dicom_encapsulated_pdf_writer_operator.py
@@ -191,7 +191,7 @@ class DICOMEncapsulatedPDFWriterOperator(Operator):
         ds.MIMETypeOfEncapsulatedDocument = "application/pdf"
         ds.EncapsulatedDocument = content_bytes
 
-        ## ConceptNameCode Sequence
+        # ConceptNameCode Sequence
         seq_concept_name_code = Sequence()
         ds_concept_name_code = Dataset()
         ds_concept_name_code.CodeValue = "18748-4"

--- a/monai/deploy/operators/dicom_encapsulated_pdf_writer_operator.py
+++ b/monai/deploy/operators/dicom_encapsulated_pdf_writer_operator.py
@@ -13,7 +13,7 @@ import logging
 from ast import Bytes
 from io import BytesIO
 from pathlib import Path
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional
 
 from PyPDF2 import PdfReader
 

--- a/monai/deploy/operators/dicom_text_sr_writer_operator.py
+++ b/monai/deploy/operators/dicom_text_sr_writer_operator.py
@@ -1,4 +1,4 @@
-# Copyright 2021 MONAI Consortium
+# Copyright 2021-2022 MONAI Consortium
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/monai/deploy/operators/dicom_text_sr_writer_operator.py
+++ b/monai/deploy/operators/dicom_text_sr_writer_operator.py
@@ -28,9 +28,8 @@ from monai.deploy.core import DataPath, ExecutionContext, InputContext, IOType, 
 from monai.deploy.core.domain.dicom_series import DICOMSeries
 from monai.deploy.core.domain.dicom_series_selection import StudySelectedSeries
 from monai.deploy.exceptions import ItemNotExistsError
+from monai.deploy.operators.dicom_utils import EquipmentInfo, ModelInfo, save_dcm_file, write_common_modules
 from monai.deploy.utils.version import get_sdk_semver
-
-from .dicom_utils import EquipmentInfo, ModelInfo, save_dcm_file, write_common_modules
 
 
 # The SR writer operator class
@@ -236,6 +235,7 @@ class DICOMTextSRWriterOperator(Operator):
         # Instance file name is the same as the new SOP instance UID
         file_path = output_dir.joinpath(f"{ds.SOPInstanceUID}{DICOMTextSRWriterOperator.DCM_EXTENSION}")
         save_dcm_file(ds, file_path)
+        self._logger.info(f"DICOM SOP instance saved in {file_path}")
 
 
 def test():

--- a/monai/deploy/operators/dicom_text_sr_writer_operator.py
+++ b/monai/deploy/operators/dicom_text_sr_writer_operator.py
@@ -9,10 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import datetime
 import logging
 from pathlib import Path
-from random import randint
 from typing import Dict, List, Optional, Text, Union
 
 from monai.deploy.utils.importutil import optional_import

--- a/monai/deploy/operators/dicom_text_sr_writer_operator.py
+++ b/monai/deploy/operators/dicom_text_sr_writer_operator.py
@@ -11,7 +11,7 @@
 
 import logging
 from pathlib import Path
-from typing import Dict, List, Optional, Text, Union
+from typing import Dict, List, Optional, Text
 
 from monai.deploy.utils.importutil import optional_import
 
@@ -47,8 +47,8 @@ class DICOMTextSRWriterOperator(Operator):
         self,
         copy_tags: bool,
         model_info: ModelInfo,
-        equipment_info: Union[EquipmentInfo, None] = None,
-        custom_tags: Union[Dict[str, str], None] = None,
+        equipment_info: Optional[EquipmentInfo] = None,
+        custom_tags: Optional[Dict[str, str]] = None,
         *args,
         **kwargs,
     ):

--- a/monai/deploy/operators/dicom_utils.py
+++ b/monai/deploy/operators/dicom_utils.py
@@ -36,6 +36,7 @@ __all__ = [
     "write_common_modules",
 ]
 
+
 class ModelInfo(object):
     """Class encapsulating AI model information, according to IHE AI Results (AIR) Rev 1.1.
 
@@ -88,6 +89,7 @@ class EquipmentInfo(object):
 
 
 # Utility functions
+
 
 def random_with_n_digits(n):
     """Random number generator to generate n digit int, where 1 <= n <= 32."""

--- a/monai/deploy/operators/dicom_utils.py
+++ b/monai/deploy/operators/dicom_utils.py
@@ -13,7 +13,7 @@ import datetime
 import logging
 from pathlib import Path
 from random import randint
-from typing import Optional
+from typing import Any, Optional
 
 from monai.deploy.utils.importutil import optional_import
 
@@ -21,12 +21,15 @@ dcmread, _ = optional_import("pydicom", name="dcmread")
 dcmwrite, _ = optional_import("pydicom.filewriter", name="dcmwrite")
 generate_uid, _ = optional_import("pydicom.uid", name="generate_uid")
 ImplicitVRLittleEndian, _ = optional_import("pydicom.uid", name="ImplicitVRLittleEndian")
-Dataset, _ = optional_import("pydicom.dataset", name="Dataset")
+Dataset_, _ = optional_import("pydicom.dataset", name="Dataset")
 FileDataset, _ = optional_import("pydicom.dataset", name="FileDataset")
 Sequence, _ = optional_import("pydicom.sequence", name="Sequence")
 
 from monai.deploy.core.domain.dicom_series import DICOMSeries
 from monai.deploy.utils.version import get_sdk_semver
+
+# To address mypy complaint
+Dataset: Any = Dataset_
 
 __all__ = [
     "EquipmentInfo",

--- a/monai/deploy/operators/dicom_utils.py
+++ b/monai/deploy/operators/dicom_utils.py
@@ -1,0 +1,279 @@
+# Copyright 2022 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+import logging
+from pathlib import Path
+from random import randint
+from typing import Optional
+
+from monai.deploy.utils.importutil import optional_import
+
+dcmread, _ = optional_import("pydicom", name="dcmread")
+dcmwrite, _ = optional_import("pydicom.filewriter", name="dcmwrite")
+generate_uid, _ = optional_import("pydicom.uid", name="generate_uid")
+ImplicitVRLittleEndian, _ = optional_import("pydicom.uid", name="ImplicitVRLittleEndian")
+Dataset, _ = optional_import("pydicom.dataset", name="Dataset")
+FileDataset, _ = optional_import("pydicom.dataset", name="FileDataset")
+Sequence, _ = optional_import("pydicom.sequence", name="Sequence")
+
+from monai.deploy.core.domain.dicom_series import DICOMSeries
+from monai.deploy.utils.version import get_sdk_semver
+
+__all__ = [
+    "EquipmentInfo",
+    "ModelInfo",
+    "random_with_n_digits",
+    "save_dcm_file",
+    "write_common_modules",
+]
+
+class ModelInfo(object):
+    """Class encapsulating AI model information, according to IHE AI Results (AIR) Rev 1.1.
+
+    The attributes of the class will be used to populate the Contributing Equipment Sequence in the DICOM IOD
+    per IHE AIR Rev 1.1, Section 6.5.3.1 General Result Encoding Requirements, as the following,
+
+    The Creator shall describe each algorithm that was used to generate the results in the
+    Contributing Equipment Sequence (0018,A001). Multiple items may be included. The Creator
+    shall encode the following details in the Contributing Equipment Sequence,
+        - Purpose of Reference Code Sequence (0040,A170) shall be (Newcode1, 99IHE, 1630 "Processing Algorithm")
+        - Manufacturer (0008,0070)
+        - Manufacturer's Model Name (0008,1090)
+        - Software Versions (0018,1020)
+        - Device UID (0018,1002)
+
+    Each time an AI Model is modified, for example by training, it would be appropriate to update
+    the Device UID.
+    """
+
+    def __init__(self, creator: str = "", name: str = "", version: str = "", uid: str = ""):
+
+        self.creator = creator if isinstance(creator, str) else ""
+        self.name = name if isinstance(name, str) else ""
+        self.version = version if isinstance(version, str) else ""
+        self.uid = uid if isinstance(uid, str) else ""
+
+
+class EquipmentInfo(object):
+    """Class encapsulating attributes required for DICOM Equipment Module."""
+
+    def __init__(
+        self,
+        manufacturer: str = "MONAI Deploy",
+        manufacturer_model: str = "MONAI Deploy App SDK",
+        series_number: str = "0000",
+        software_version_number: str = "",
+    ):
+
+        self.manufacturer = manufacturer if isinstance(manufacturer, str) else ""
+        self.manufacturer_model = manufacturer_model if isinstance(manufacturer_model, str) else ""
+        self.series_number = series_number if isinstance(series_number, str) else ""
+        if software_version_number:
+            self.software_version_number = str(software_version_number)[0:15]
+        else:
+            try:
+                version_str = get_sdk_semver()  # SDK Version
+            except Exception:
+                version_str = ""  # Fall back to the initial version
+            self.software_version_number = version_str[0:15]
+
+
+# Utility functions
+
+def random_with_n_digits(n):
+    """Random number generator to generate n digit int, where 1 <= n <= 32."""
+
+    assert isinstance(n, int) and n <= 32, "Argument n must be an int, n <= 32."
+    n = n if n >= 1 else 1
+    range_start = 10 ** (n - 1)
+    range_end = (10**n) - 1
+    return randint(range_start, range_end)
+
+
+def save_dcm_file(data_set: Dataset, file_path: Path, validate_readable: bool = True):
+    """Save a DICOM data set, in pydicom Dataset, to the provided file path."""
+
+    logging.debug(f"DICOM dataset to be written:{data_set}")
+
+    if not isinstance(data_set, Dataset):
+        raise ValueError("data_set is not the expected Dataset type.")
+
+    if not str(file_path).strip():
+        raise ValueError("file_path to save dcm file not provided.")
+
+    dcmwrite(str(file_path).strip(), data_set, write_like_original=False)
+    logging.info(f"Finished writing DICOM instance to file {file_path}")
+
+    if validate_readable:
+        # Test reading back
+        _ = dcmread(str(file_path))
+
+
+def write_common_modules(
+    dicom_series: Optional[DICOMSeries],
+    copy_tags: bool,
+    modality_type: str,
+    sop_class_uid: str,
+    model_info: Optional[ModelInfo] = None,
+    equipment_info: Optional[EquipmentInfo] = None,
+) -> Dataset:
+    """Writes DICOM object common modules with or without a reference DCIOM Series
+
+    Common modules include Study, Patient, Equipment, Series, and SOP common.
+
+    Args:
+        dicom_series (DicomSeries): DicomSeries object encapsulating the original series.
+        copy_tags (bool): If true, dicom_series must be provided for copying tags.
+        modality_type (str): DICOM Modality Type, e.g. SR.
+        sop_class_uid (str): Media Storage SOP Class UID, e.g. "1.2.840.10008.5.1.4.1.1.88.34" for Comprehensive 3D SR IOD.
+        model_info (MoelInfo): Object encapsulating model creator, name, version and UID.
+        equipment_info(EquipmentInfo): Object encapsulating attributes for DICOM Equipment Module
+
+    Returns:
+        pydicom Dataset
+
+    Raises:
+        ValueError: When dicom_series is not a DICOMSeries object, and new_study is not True.
+    """
+
+    if copy_tags:
+        if not isinstance(dicom_series, DICOMSeries):
+            raise ValueError("A DICOMSeries object is required for coping tags.")
+
+        if len(dicom_series.get_sop_instances()) < 1:
+            raise ValueError("DICOMSeries must have at least one SOP instance.")
+
+        # Get one of the SOP instance's native sop instance dataset
+        orig_ds = dicom_series.get_sop_instances()[0].get_native_sop_instance()
+
+    logging.debug("Writing DICOM common modules...")
+
+    # Get and format date and time per DICOM standards.
+    dt_now = datetime.datetime.now()
+    date_now_dcm = dt_now.strftime("%Y%m%d")
+    time_now_dcm = dt_now.strftime("%H%M%S")
+    offset_from_utc = dt_now.astimezone().isoformat()[-6:].replace(":", "")  # '2022-09-27T22:36:20.143857-07:00'
+
+    # Generate UIDs and descriptions
+    my_sop_instance_uid = generate_uid()
+    my_series_instance_uid = generate_uid()
+    my_series_description = "CAUTION: Not for Diagnostic Use, for research use only."
+    my_series_number = str(random_with_n_digits(4))  # 4 digit number to avoid conflict
+    my_study_instance_uid = orig_ds.StudyInstanceUID if copy_tags else generate_uid()
+
+    # File meta info data set
+    file_meta = Dataset()
+    file_meta.FileMetaInformationGroupLength = 198
+    file_meta.FileMetaInformationVersion = bytes("01", "utf-8")  # '\x00\x01'
+
+    file_meta.MediaStorageSOPClassUID = sop_class_uid
+    file_meta.MediaStorageSOPInstanceUID = my_sop_instance_uid
+    file_meta.TransferSyntaxUID = ImplicitVRLittleEndian  # 1.2.840.10008.1.2, Little Endian Implicit VR
+    file_meta.ImplementationClassUID = "1.2.40.0.13.1.1.1"  # Made up. Not registered.
+    file_meta.ImplementationVersionName = equipment_info.software_version_number if equipment_info else ""
+
+    # Write modules to data set
+    ds = Dataset()
+    ds.file_meta = file_meta
+    ds.is_implicit_VR = True
+    ds.is_little_endian = True
+
+    # Content Date (0008,0023) and Content Time (0008,0033) are defined to be the date and time that
+    # the document content creation started. In the context of analysis results, these may be considered
+    # to be the date and time that the analysis that generated the result(s) started executing.
+    # Use current time for now, but could potentially use the actual inference start time.
+    ds.ContentDate = date_now_dcm
+    ds.ContentTime = time_now_dcm
+    ds.TimezoneOffsetFromUTC = offset_from_utc
+
+    # The date and time that the original generation of the data in the document started.
+    ds.AcquisitionDateTime = date_now_dcm + time_now_dcm  # Result has just been created.
+
+    # Patient Module, mandatory.
+    # Copy over from the original DICOM metadata.
+    ds.PatientName = orig_ds.get("PatientName", "") if copy_tags else ""
+    ds.PatientID = orig_ds.get("PatientID", "") if copy_tags else ""
+    ds.IssuerOfPatientID = orig_ds.get("IssuerOfPatientID", "") if copy_tags else ""
+    ds.PatientBirthDate = orig_ds.get("PatientBirthDate", "") if copy_tags else ""
+    ds.PatientSex = orig_ds.get("PatientSex", "") if copy_tags else ""
+
+    # Study Module, mandatory
+    # Copy over from the original DICOM metadata.
+    ds.StudyDate = orig_ds.get("StudyDate", "") if copy_tags else date_now_dcm
+    ds.StudyTime = orig_ds.get("StudyTime", "") if copy_tags else time_now_dcm
+    ds.AccessionNumber = orig_ds.get("AccessionNumber", "") if copy_tags else ""
+    ds.StudyDescription = orig_ds.get("StudyDescription", "") if copy_tags else "AI results."
+    ds.StudyInstanceUID = my_study_instance_uid
+    ds.StudyID = orig_ds.get("StudyID", "") if copy_tags else "1"
+    ds.ReferringPhysicianName = orig_ds.get("ReferringPhysicianName", "") if copy_tags else ""
+
+    # Equipment Module, mandatory
+    if equipment_info:
+        ds.Manufacturer = equipment_info.manufacturer
+        ds.ManufacturerModelName = equipment_info.manufacturer_model
+        ds.SeriesNumber = equipment_info.series_number
+        ds.SoftwareVersions = equipment_info.software_version_number
+
+    # SOP Common Module, mandatory
+    ds.InstanceCreationDate = date_now_dcm
+    ds.InstanceCreationTime = time_now_dcm
+    ds.SOPClassUID = sop_class_uid
+    ds.SOPInstanceUID = my_sop_instance_uid
+    ds.InstanceNumber = "1"
+    ds.SpecificCharacterSet = "ISO_IR 100"
+
+    # Series Module, mandatory
+    ds.Modality = modality_type
+    ds.SeriesInstanceUID = my_series_instance_uid
+    ds.SeriesNumber = my_series_number
+    ds.SeriesDescription = my_series_description
+    ds.SeriesDate = date_now_dcm
+    ds.SeriesTime = time_now_dcm
+    # Body part copied over, although not mandatory depending on modality
+    ds.BodyPartExamined = orig_ds.get("BodyPartExamined", "") if copy_tags else ""
+    ds.RequestedProcedureID = orig_ds.get("RequestedProcedureID", "") if copy_tags else ""
+
+    # Contributing Equipment Sequence
+    # The Creator shall describe each algorithm that was used to generate the results in the
+    # Contributing Equipment Sequence (0018,A001). Multiple items may be included. The Creator
+    # shall encode the following details in the Contributing Equipment Sequence:
+    #  • Purpose of Reference Code Sequence (0040,A170) shall be (Newcode1, 99IHE, 1630 "Processing Algorithm")
+    #  • Manufacturer (0008,0070)
+    #  • Manufacturer’s Model Name (0008,1090)
+    #  • Software Versions (0018,1020)
+    #  • Device UID (0018,1002)
+
+    if model_info:
+        # First create the Purpose of Reference Code Sequence
+        seq_purpose_of_reference_code = Sequence()
+        ds_purpose_of_reference_code = Dataset()
+        ds_purpose_of_reference_code.CodeValue = "Newcode1"
+        ds_purpose_of_reference_code.CodingSchemeDesignator = "99IHE"
+        ds_purpose_of_reference_code.CodeMeaning = '"Processing Algorithm'
+        seq_purpose_of_reference_code.append(ds_purpose_of_reference_code)
+
+        seq_contributing_equipment = Sequence()
+        ds_contributing_equipment = Dataset()
+        ds_contributing_equipment.PurposeOfReferenceCodeSequence = seq_purpose_of_reference_code
+        # '(121014, DCM, “Device Observer Manufacturer")'
+        ds_contributing_equipment.Manufacturer = model_info.creator
+        # u'(121015, DCM, “Device Observer Model Name")'
+        ds_contributing_equipment.ManufacturerModelName = model_info.name
+        # u'(111003, DCM, “Algorithm Version")'
+        ds_contributing_equipment.SoftwareVersions = model_info.version
+        ds_contributing_equipment.DeviceUID = model_info.uid  # u'(121012, DCM, “Device Observer UID")'
+        seq_contributing_equipment.append(ds_contributing_equipment)
+        ds.ContributingEquipmentSequence = seq_contributing_equipment
+
+    logging.debug("DICOM common modules written:\n{}".format(ds))
+
+    return ds


### PR DESCRIPTION
This PR is to:
- split from the existing text SR writer the dicom_utils module for reusable classes and function, e.g. equipment info, model info, DICOM common module writer for study, patient, SOP commons, etc.
- the DICOM Text Writer becomes much smaller and clearer to read
- the DICOM Encapsulated PDF write is added with minimal amount of code. This new writer take in either PDF bytes or a file path to load byte from, optionally with a DICOM Series for copying study level tags, and writes the DICOM Encapsulated PDF instance file. The loaded PDF in bytes are validated for being PDF with the use of PyPDF2  
- the app that uses the Text SR writer, mednist classification, is updated with simple change. This app is also used as the tester, even though the writers have test function for testing the operator standalone
- the license for the third party PyPDF2 is added

By the way, the SonarCloud failures are false positives, on some bogus code duplication findings. I have reviewed them and marking them as info.

Screenshot of the DICOM Text SR and Encapsulated PDF viewed in MicroDICOM:

![image](https://user-images.githubusercontent.com/38891913/194812167-af0b9032-40e6-48e2-ae1a-a10920360f74.png)

![image](https://user-images.githubusercontent.com/38891913/194812470-2ee74004-8268-42ec-9b0c-3d021f865011.png)

Screenshot of actual PDF opened from MicroDICOM
![image](https://user-images.githubusercontent.com/38891913/194813076-61ca87bd-56f6-4cfe-a13c-1a0d2e67e018.png)

   
Signed-off-by: M Q <mingmelvinq@nvidia.com>