### PR TITLE
Enhanced multi-value DataElement parsing

### DIFF
--- a/monai/deploy/operators/dicom_series_selector_operator.py
+++ b/monai/deploy/operators/dicom_series_selector_operator.py
@@ -225,7 +225,13 @@ class DICOMSeriesSelectorOperator(Operator):
                 # This is mainly for attributes like ImageType
                 if not attr_value:
                     try:
-                        attr_value = [series.get_sop_instances()[0].get_native_sop_instance()[key].repval]
+                        # Can use some enhancements, especially multi-value where VM > 1
+                        elem = series.get_sop_instances()[0].get_native_sop_instance()[key]
+                        if elem.VM > 1:
+                            attr_value = [elem.repval]  # repval: str representation of the element’s value
+                        else:
+                            attr_value = elem.value  # element's value
+
                         series_attr.update({key: attr_value})
                     except Exception:
                         logging.info(f"        Attribute {key} not at instance level either.")


### PR DESCRIPTION
This PR enhances the code to treat multi-value DataElement retrieved from SOP instance Dataset differently from single valued ones.

DataElement retrieved from the underlying SOP instance Dataset may be multiple-valued; the retrieval is only needed when the to-be-matched attribute is not in the defined set of study and series attributes and when instance level attributes are used. The existing implementation favors multiple-valued and converts the string representation of the multi-valued into a list, however this also makes a single value into a list which then causes issue when valuating the condition.
   
Signed-off-by: M Q <mingmelvinq@nvidia.com>