### PR TITLE
ENH: Versions as strings, not numbers, so that 3.1 != 3.10, etc.

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: "3.7"
       - name: Setup Dev Environment
         run: |
           pip install virtualenv


### PR DESCRIPTION
Re-writes version numbers as strings rather than as numbers in `.github/workflows/*.yml` files because 3.1 != 3.10, etc.  Nothing is broken at present but in the future as, e.g., a Python version goes from 3.8 to 3.9 to 3.10, this could end up being an unexpected problem.

Signed-off-by: Lee Newberg <lee.newberg@kitware.com>