### PR TITLE
Quick fix to avoid package not found error by use optional import

### DIFF
--- a/monai/deploy/operators/nii_data_loader_operator.py
+++ b/monai/deploy/operators/nii_data_loader_operator.py
@@ -10,10 +10,12 @@
 # limitations under the License.
 
 import numpy as np
-import SimpleITK
 
 import monai.deploy.core as md
 from monai.deploy.core import DataPath, ExecutionContext, InputContext, IOType, Operator, OutputContext
+from monai.deploy.utils.importutil import optional_import
+
+SimpleITK, _ = optional_import("SimpleITK")
 
 
 @md.input("image_path", DataPath, IOType.DISK)
@@ -42,7 +44,7 @@ class NiftiDataLoader(Operator):
 def test():
     filepath = "/home/gupta/Documents/mni_icbm152_nlin_sym_09a/mni_icbm152_gm_tal_nlin_sym_09a.nii"
     nii_operator = NiftiDataLoader()
-    image_np = nii_operator.convert_and_save(filepath)
+    _ = nii_operator.convert_and_save(filepath)
 
 
 def main():

--- a/monai/deploy/operators/nii_data_loader_operator.py
+++ b/monai/deploy/operators/nii_data_loader_operator.py
@@ -20,6 +20,7 @@ SimpleITK, _ = optional_import("SimpleITK")
 
 @md.input("image_path", DataPath, IOType.DISK)
 @md.output("image", np.ndarray, IOType.IN_MEMORY)
+@md.env(pip_packages=["SimpleITK>=2.0.2"])
 class NiftiDataLoader(Operator):
     """
     This operator reads a nifti image, extracts the numpy array and forwards it to the next operator


### PR DESCRIPTION
This quick fix is needed to avoid MAP container runtime errors by using optional import on packages that are used by an App SDK built-in operator but not all application.

Also the dependent package needs to be stated in the operator's decorator so that this dependency is collected and become part of the requirements file when building MAP container image.


Signed-off-by: M Q <mingmelvinq@nvidia.com>