### PR TITLE
Fix runtime error for MAP of breast density classification app

### DIFF
--- a/examples/apps/breast_density_classifer_app/app.py
+++ b/examples/apps/breast_density_classifer_app/app.py
@@ -1,12 +1,13 @@
 from breast_density_classifier_operator import ClassifierOperator
 
-from monai.deploy.core import Application
+from monai.deploy.core import Application, env
 from monai.deploy.operators.dicom_data_loader_operator import DICOMDataLoaderOperator
 from monai.deploy.operators.dicom_series_selector_operator import DICOMSeriesSelectorOperator
 from monai.deploy.operators.dicom_series_to_volume_operator import DICOMSeriesToVolumeOperator
 from monai.deploy.operators.dicom_text_sr_writer_operator import DICOMTextSRWriterOperator, EquipmentInfo, ModelInfo
 
 
+@env(pip_packages=["highdicom>=0.18.2"])
 class BreastClassificationApp(Application):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -36,7 +37,7 @@ class BreastClassificationApp(Application):
         self.add_flow(classifier_op, sr_writer_op, {"result_text": "classification_result"})
 
 
-def main():
+def test():
     app = BreastClassificationApp()
     image_dir = "./sampleDICOMs/1/BI_BREAST_SCREENING_BILATERAL_WITH_TOMOSYNTHESIS-2019-07-08/1/L_CC_C-View"
 
@@ -45,4 +46,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    app = BreastClassificationApp(do_run=True)


### PR DESCRIPTION
Needed to provided this fix after building and testing MAP of the breast density classification app
- Somehow highdicom dependency is dragged in. Add this package in the App pip_packages decorator to avoid runtime error.
- Need to change the app.py __main__ function to directly init and run the app object, because the packager sets the command to run app.py instead of app/. Need to rename the original main() which served as test function to test()
- Published the MAP on ghcr.io, http://ghcr.io/mmelqin/monai_ai_breast_density_cls_app:1.0, to be used as a candidate in the AWS Imaging Service integration demo

Signed-off-by: M Q <mingmelvinq@nvidia.com>