### PR TITLE
Fix issue 410 where the latest typeguard version 3.x is incompatible

### DIFF
--- a/examples/apps/ai_livertumor_seg_app/livertumor_seg_operator.py
+++ b/examples/apps/ai_livertumor_seg_app/livertumor_seg_operator.py
@@ -52,14 +52,12 @@ class LiverTumorSegOperator(Operator):
     """
 
     def __init__(self):
-
         self.logger = logging.getLogger("{}.{}".format(__name__, type(self).__name__))
         super().__init__()
         self._input_dataset_key = "image"
         self._pred_dataset_key = "pred"
 
     def compute(self, op_input: InputContext, op_output: OutputContext, context: ExecutionContext):
-
         input_image = op_input.get("image")
         if not input_image:
             raise ValueError("Input image is not found.")

--- a/examples/apps/ai_unetr_seg_app/unetr_seg_operator.py
+++ b/examples/apps/ai_unetr_seg_app/unetr_seg_operator.py
@@ -46,14 +46,12 @@ class UnetrSegOperator(Operator):
     """
 
     def __init__(self):
-
         self.logger = logging.getLogger("{}.{}".format(__name__, type(self).__name__))
         super().__init__()
         self._input_dataset_key = "image"
         self._pred_dataset_key = "pred"
 
     def compute(self, op_input: InputContext, op_output: OutputContext, context: ExecutionContext):
-
         input_image = op_input.get("image")
         if not input_image:
             raise ValueError("Input image is not found.")

--- a/monai/deploy/core/application.py
+++ b/monai/deploy/core/application.py
@@ -82,7 +82,7 @@ class Application(ABC):
             self.description = get_docstring(self.__class__)
         if not self.version:
             try:
-                from _version import get_versions
+                from monai.deploy._version import get_versions
 
                 self.version = get_versions()["version"]
             except ImportError:

--- a/monai/deploy/core/executors/single_process_executor.py
+++ b/monai/deploy/core/executors/single_process_executor.py
@@ -141,7 +141,7 @@ class SingleProcessExecutor(Executor):
                         )
 
                     next_op_exec_context = ExecutionContext(exec_context, next_op)
-                    for (out_label, in_labels) in io_map.items():
+                    for out_label, in_labels in io_map.items():
                         output = op_exec_context.output_context.get(out_label)
                         for in_label in in_labels:
                             next_op_exec_context.input_context.set(output, in_label)

--- a/monai/deploy/core/graphs/nx_digraph.py
+++ b/monai/deploy/core/graphs/nx_digraph.py
@@ -52,5 +52,5 @@ class NetworkXGraph(Graph):
         return worklist
 
     def gen_next_operators(self, op: Operator) -> Generator[Optional[Operator], None, None]:
-        for (_, v) in self._graph.out_edges(op):
+        for _, v in self._graph.out_edges(op):
             yield v

--- a/monai/deploy/operators/dicom_data_loader_operator.py
+++ b/monai/deploy/operators/dicom_data_loader_operator.py
@@ -118,7 +118,6 @@ class DICOMDataLoaderOperator(Operator):
                 logging.warning(f"Ignored {file}, reason being: {ex}")
 
         for sop_instance in sop_instances:
-
             study_instance_uid = sop_instance[0x0020, 0x000D].value.name  # name is the UID as str
 
             if study_instance_uid not in study_dict:

--- a/monai/deploy/operators/dicom_encapsulated_pdf_writer_operator.py
+++ b/monai/deploy/operators/dicom_encapsulated_pdf_writer_operator.py
@@ -42,7 +42,6 @@ from monai.deploy.utils.version import get_sdk_semver
 @md.output("dicom_instance", DataPath, IOType.DISK)
 @md.env(pip_packages=["pydicom >= 1.4.2", "PyPDF2 >= 2.11.1", "monai"])
 class DICOMEncapsulatedPDFWriterOperator(Operator):
-
     DCM_EXTENSION = ".dcm"
 
     def __init__(

--- a/monai/deploy/operators/dicom_seg_writer_operator.py
+++ b/monai/deploy/operators/dicom_seg_writer_operator.py
@@ -9,6 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import datetime
 import logging
 from pathlib import Path

--- a/monai/deploy/operators/dicom_seg_writer_operator.py
+++ b/monai/deploy/operators/dicom_seg_writer_operator.py
@@ -9,9 +9,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import datetime
 import logging
+import os
 from pathlib import Path
 from random import randint
 from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Union

--- a/monai/deploy/operators/dicom_series_to_volume_operator.py
+++ b/monai/deploy/operators/dicom_series_to_volume_operator.py
@@ -389,7 +389,6 @@ class DICOMSeriesToVolumeOperator(Operator):
 
 
 def test():
-
     from pathlib import Path
 
     from monai.deploy.operators.dicom_data_loader_operator import DICOMDataLoaderOperator

--- a/monai/deploy/operators/dicom_text_sr_writer_operator.py
+++ b/monai/deploy/operators/dicom_text_sr_writer_operator.py
@@ -39,7 +39,6 @@ from monai.deploy.utils.version import get_sdk_semver
 @md.output("dicom_instance", DataPath, IOType.DISK)
 @md.env(pip_packages=["pydicom >= 1.4.2", "monai"])
 class DICOMTextSRWriterOperator(Operator):
-
     # File extension for the generated DICOM Part 10 file.
     DCM_EXTENSION = ".dcm"
 

--- a/monai/deploy/operators/dicom_utils.py
+++ b/monai/deploy/operators/dicom_utils.py
@@ -60,7 +60,6 @@ class ModelInfo(object):
     """
 
     def __init__(self, creator: str = "", name: str = "", version: str = "", uid: str = ""):
-
         self.creator = creator if isinstance(creator, str) else ""
         self.name = name if isinstance(name, str) else ""
         self.version = version if isinstance(version, str) else ""
@@ -77,7 +76,6 @@ class EquipmentInfo(object):
         series_number: str = "0000",
         software_version_number: str = "",
     ):
-
         self.manufacturer = manufacturer if isinstance(manufacturer, str) else ""
         self.manufacturer_model = manufacturer_model if isinstance(manufacturer_model, str) else ""
         self.series_number = series_number if isinstance(series_number, str) else ""

--- a/monai/deploy/operators/monai_bundle_inference_operator.py
+++ b/monai/deploy/operators/monai_bundle_inference_operator.py
@@ -587,7 +587,7 @@ class MonaiBundleInferenceOperator(InferenceOperator):
             outputs = self.post_process(ensure_tuple(outputs)[0], **kw_args)
             logging.debug(f"Post-processing elapsed time (seconds): {time.time() - start}")
         if isinstance(outputs, (tuple, list)):
-            output_dict = dict(zip(self._outputs.keys(), outputs))
+            output_dict = dict(zip(self._outputs.keys(), outputs), strict=True)
         elif not isinstance(outputs, dict):
             output_dict = {first(self._outputs.keys()): outputs}
         else:

--- a/monai/deploy/operators/monai_bundle_inference_operator.py
+++ b/monai/deploy/operators/monai_bundle_inference_operator.py
@@ -622,7 +622,7 @@ class MonaiBundleInferenceOperator(InferenceOperator):
 
         if is_map_compose(self._postproc):
             if isinstance(data, (list, tuple)):
-                outputs_dict = dict(zip(data, self._outputs.keys()))
+                outputs_dict = dict(zip(data, self._outputs.keys(), strict=True))
             elif not isinstance(data, dict):
                 oname = first(self._outputs.keys())
                 outputs_dict = {oname: data}

--- a/monai/deploy/operators/monai_bundle_inference_operator.py
+++ b/monai/deploy/operators/monai_bundle_inference_operator.py
@@ -78,8 +78,8 @@ def get_bundle_config(bundle_path, config_names):
 
         # Try directly read with constructed and expected path into the archive
         for suffix in bundle_suffixes:
+            path = Path(root_name, config_folder, config_name).with_suffix(suffix)
             try:
-                path = Path(root_name, config_folder, config_name).with_suffix(suffix)
                 logging.debug(f"Trying to read config '{config_name}' content from {path}.")
                 content_text = archive.read(str(path))
                 break
@@ -587,7 +587,7 @@ class MonaiBundleInferenceOperator(InferenceOperator):
             outputs = self.post_process(ensure_tuple(outputs)[0], **kw_args)
             logging.debug(f"Post-processing elapsed time (seconds): {time.time() - start}")
         if isinstance(outputs, (tuple, list)):
-            output_dict = dict(zip(self._outputs.keys(), outputs, strict=True))
+            output_dict = dict(zip(self._outputs.keys(), outputs))
         elif not isinstance(outputs, dict):
             output_dict = {first(self._outputs.keys()): outputs}
         else:
@@ -622,7 +622,7 @@ class MonaiBundleInferenceOperator(InferenceOperator):
 
         if is_map_compose(self._postproc):
             if isinstance(data, (list, tuple)):
-                outputs_dict = dict(zip(data, self._outputs.keys(), strict=True))
+                outputs_dict = dict(zip(data, self._outputs.keys()))
             elif not isinstance(data, dict):
                 oname = first(self._outputs.keys())
                 outputs_dict = {oname: data}

--- a/monai/deploy/operators/monai_bundle_inference_operator.py
+++ b/monai/deploy/operators/monai_bundle_inference_operator.py
@@ -268,6 +268,7 @@ class BundleConfigNames:
 
 DEFAULT_BundleConfigNames = BundleConfigNames()
 
+
 # The operator env decorator defines the required pip packages commonly used in the Bundles.
 # The MONAI Deploy App SDK packager currently relies on the App to consolidate all required packages in order to
 # install them in the MAP Docker image.
@@ -768,7 +769,6 @@ class MonaiBundleInferenceOperator(InferenceOperator):
             or ("spacing" in img_meta_dict and "original_affine" in img_meta_dict)
             or "row_pixel_spacing" not in img_meta_dict
         ):
-
             return img.asnumpy(), img_meta_dict
         else:
             return self._convert_from_image_dicom_source(img)

--- a/monai/deploy/operators/monai_bundle_inference_operator.py
+++ b/monai/deploy/operators/monai_bundle_inference_operator.py
@@ -587,7 +587,7 @@ class MonaiBundleInferenceOperator(InferenceOperator):
             outputs = self.post_process(ensure_tuple(outputs)[0], **kw_args)
             logging.debug(f"Post-processing elapsed time (seconds): {time.time() - start}")
         if isinstance(outputs, (tuple, list)):
-            output_dict = dict(zip(self._outputs.keys(), outputs), strict=True)
+            output_dict = dict(zip(self._outputs.keys(), outputs, strict=True))
         elif not isinstance(outputs, dict):
             output_dict = {first(self._outputs.keys()): outputs}
         else:

--- a/monai/deploy/utils/importutil.py
+++ b/monai/deploy/utils/importutil.py
@@ -155,7 +155,7 @@ def exact_version(the_module, version_str: str = "") -> bool:
     Returns True if the module's __version__ matches version_str
     """
     if not hasattr(the_module, "__version__"):
-        warnings.warn(f"{the_module} has no attribute __version__ in exact_version check.")
+        warnings.warn(f"{the_module} has no attribute __version__ in exact_version check.", stacklevel=2)
         return False
     return bool(the_module.__version__ == version_str)
 

--- a/notebooks/tutorials/02_mednist_app-prebuilt.ipynb
+++ b/notebooks/tutorials/02_mednist_app-prebuilt.ipynb
@@ -84,7 +84,7 @@
       "Collecting networkx>=2.4\n",
       "  Downloading networkx-2.5.1-py3-none-any.whl (1.6 MB)\n",
       "\u001b[K     |████████████████████████████████| 1.6 MB 12.8 MB/s eta 0:00:01\n",
-      "\u001b[?25hCollecting typeguard>=2.12.1\n",
+      "\u001b[?25hCollecting typeguard~=2.12.1\n",
       "  Downloading typeguard-2.12.1-py3-none-any.whl (17 kB)\n",
       "Collecting numpy>=1.17\n",
       "  Downloading numpy-1.19.5-cp36-cp36m-manylinux2010_x86_64.whl (14.8 MB)\n",

--- a/notebooks/tutorials/03_segmentation_app.ipynb
+++ b/notebooks/tutorials/03_segmentation_app.ipynb
@@ -104,7 +104,7 @@
     "!python -c \"import pydicom\" || pip install -q \"pydicom>=1.4.2\"\n",
     "!python -c \"import highdicom\" || pip install -q \"highdicom>=0.18.2\"\n",
     "!python -c \"import SimpleITK\" || pip install -q \"SimpleITK>=2.0.0\"\n",
-    "!python -c \"import typeguard\" || pip install -q \"typeguard>=2.12.1\"\n",
+    "!python -c \"import typeguard\" || pip install -q \"typeguard~=2.12.1\"\n",
     "\n",
     "# Install MONAI Deploy App SDK package\n",
     "!python -c \"import monai.deploy\" || pip install --upgrade -q \"monai-deploy-app-sdk\""

--- a/notebooks/tutorials/03_segmentation_viz_app.ipynb
+++ b/notebooks/tutorials/03_segmentation_viz_app.ipynb
@@ -113,7 +113,7 @@
     "!python -c \"import pydicom\" || pip install -q \"pydicom>=1.4.2\"\n",
     "!python -c \"import highdicom\" || pip install -q \"highdicom>=0.18.2\"\n",
     "!python -c \"import SimpleITK\" || pip install -q \"SimpleITK>=2.0.0\"\n",
-    "!python -c \"import typeguard\" || pip install -q \"typeguard>=2.12.1\"\n",
+    "!python -c \"import typeguard\" || pip install -q \"typeguard~=2.12.1\"\n",
     "\n",
     "# Install MONAI Deploy App SDK package\n",
     "!python -c \"import monai.deploy\" || pip install --upgrade -q \"monai-deploy-app-sdk\"\n",

--- a/notebooks/tutorials/06_monai_bundle_app.ipynb
+++ b/notebooks/tutorials/06_monai_bundle_app.ipynb
@@ -106,7 +106,7 @@
     "!python -c \"import pydicom\" || pip install -q \"pydicom>=1.4.2\"\n",
     "!python -c \"import highdicom\" || pip install -q \"highdicom>=0.18.2\"\n",
     "!python -c \"import SimpleITK\" || pip install -q \"SimpleITK>=2.0.0\"\n",
-    "!python -c \"import typeguard\" || pip install -q \"typeguard>=2.12.1\"\n",
+    "!python -c \"import typeguard\" || pip install -q \"typeguard~=2.12.1\"\n",
     "\n",
     "# Install MONAI Deploy App SDK package\n",
     "!python -c \"import monai.deploy\" || pip install --upgrade -q \"monai-deploy-app-sdk\""

--- a/notebooks/tutorials/07_multi_model_app.ipynb
+++ b/notebooks/tutorials/07_multi_model_app.ipynb
@@ -144,7 +144,7 @@
     "!python -c \"import pydicom\" || pip install -q \"pydicom>=1.4.2\"\n",
     "!python -c \"import highdicom\" || pip install -q \"highdicom>=0.18.2\"\n",
     "!python -c \"import SimpleITK\" || pip install -q \"SimpleITK>=2.0.0\"\n",
-    "!python -c \"import typeguard\" || pip install -q \"typeguard>=2.12.1\"\n",
+    "!python -c \"import typeguard\" || pip install -q \"typeguard~=2.12.1\"\n",
     "\n",
     "# Install MONAI Deploy App SDK package\n",
     "!python -c \"import monai.deploy\" || pip install --upgrade -q \"monai-deploy-app-sdk\""

--- a/platforms/nuance_pin/app/inference.py
+++ b/platforms/nuance_pin/app/inference.py
@@ -82,7 +82,6 @@ class DetectionResultList(Domain):
 @md.env(pip_packages=["monai>=0.8.1", "torch>=1.5", "numpy>=1.21", "nibabel"])
 class LungNoduleInferenceOperator(Operator):
     def __init__(self, model_path: str = "model/model.ts"):
-
         self.logger = logging.getLogger("{}.{}".format(__name__, type(self).__name__))
         super().__init__()
         self._input_dataset_key = "image"
@@ -125,7 +124,6 @@ class LungNoduleInferenceOperator(Operator):
         self.detector.eval()
 
     def compute(self, op_input: InputContext, op_output: OutputContext, context: ExecutionContext):
-
         input_image = op_input.get("image")
         if not input_image:
             raise ValueError("Input image not found.")

--- a/platforms/nuance_pin/app/post_inference_ops.py
+++ b/platforms/nuance_pin/app/post_inference_ops.py
@@ -36,7 +36,6 @@ class GenerateGSPSOp(Operator):
         self.pin_processor = pin_processor
 
     def compute(self, op_input: InputContext, op_output: OutputContext, context: ExecutionContext):
-
         selected_study = op_input.get("original_dicom")[0]  # assuming a single study
         selected_series = selected_study.selected_series[0]  # assuming a single series
         detection_result: DetectionResult = op_input.get("detection_predictions").detection_list[0]
@@ -60,7 +59,6 @@ class GenerateGSPSOp(Operator):
         accession = all_ref_images[0].AccessionNumber
 
         for inst_num, (box_data, box_score) in enumerate(zip(detection_result.box_data, detection_result.score_data)):
-
             tracking_id = f"{accession}_nodule_{inst_num}"  # site-specific ID
             tracking_uid = hd.UID()
 
@@ -160,7 +158,6 @@ class CreatePINDiagnosticsReportOp(Operator):
         self.pin_processor = pin_processor
 
     def compute(self, op_input: InputContext, op_output: OutputContext, context: ExecutionContext):
-
         selected_study = op_input.get("original_dicom")[0]  # assuming a single study
         selected_series = selected_study.selected_series[0]  # assuming a single series
         detection_result: DetectionResult = op_input.get("detection_predictions").detection_list[0]
@@ -190,7 +187,6 @@ class CreatePINDiagnosticsReportOp(Operator):
         slice_coords = list(range(len(selected_series.series.get_sop_instances())))
 
         for box_data, box_score in zip(detection_result.box_data, detection_result.score_data):
-
             affected_slice_idx = [
                 idx
                 for idx, slice_coord in enumerate(slice_coords)

--- a/platforms/nuance_pin/app/post_inference_ops.py
+++ b/platforms/nuance_pin/app/post_inference_ops.py
@@ -58,9 +58,7 @@ class GenerateGSPSOp(Operator):
         all_ref_images = [ins.get_native_sop_instance() for ins in selected_series.series.get_sop_instances()]
         accession = all_ref_images[0].AccessionNumber
 
-        for inst_num, (box_data, box_score) in enumerate(
-            zip(detection_result.box_data, detection_result.score_data, strict=True)
-        ):
+        for inst_num, (box_data, box_score) in enumerate(zip(detection_result.box_data, detection_result.score_data)):
             tracking_id = f"{accession}_nodule_{inst_num}"  # site-specific ID
             tracking_uid = hd.UID()
 
@@ -188,7 +186,7 @@ class CreatePINDiagnosticsReportOp(Operator):
 
         slice_coords = list(range(len(selected_series.series.get_sop_instances())))
 
-        for box_data, box_score in zip(detection_result.box_data, detection_result.score_data, strict=True):
+        for box_data, box_score in zip(detection_result.box_data, detection_result.score_data):
             affected_slice_idx = [
                 idx
                 for idx, slice_coord in enumerate(slice_coords)

--- a/platforms/nuance_pin/app/post_inference_ops.py
+++ b/platforms/nuance_pin/app/post_inference_ops.py
@@ -58,7 +58,9 @@ class GenerateGSPSOp(Operator):
         all_ref_images = [ins.get_native_sop_instance() for ins in selected_series.series.get_sop_instances()]
         accession = all_ref_images[0].AccessionNumber
 
-        for inst_num, (box_data, box_score) in enumerate(zip(detection_result.box_data, detection_result.score_data)):
+        for inst_num, (box_data, box_score) in enumerate(
+            zip(detection_result.box_data, detection_result.score_data, strict=True)
+        ):
             tracking_id = f"{accession}_nodule_{inst_num}"  # site-specific ID
             tracking_uid = hd.UID()
 
@@ -186,7 +188,7 @@ class CreatePINDiagnosticsReportOp(Operator):
 
         slice_coords = list(range(len(selected_series.series.get_sop_instances())))
 
-        for box_data, box_score in zip(detection_result.box_data, detection_result.score_data):
+        for box_data, box_score in zip(detection_result.box_data, detection_result.score_data, strict=True):
             affected_slice_idx = [
                 idx
                 for idx, slice_coord in enumerate(slice_coords)

--- a/platforms/nuance_pin/app_wrapper.py
+++ b/platforms/nuance_pin/app_wrapper.py
@@ -50,7 +50,6 @@ from result import ResultStatus
 
 
 class MONAIAppWrapper(AiJobProcessor):
-
     partner_name = os.environ["AI_PARTNER_NAME"]
     service_name = os.environ["AI_SVC_NAME"]
     service_version = os.environ["AI_SVC_VERSION"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,5 +36,78 @@ exclude = '''
 '''
 
 # https://github.com/microsoft/pyright/blob/main/docs/configuration.md
+# NOTE: All relative paths are relative to the location of this file.
 [tool.pyright]
 ignore = ["versioneer.py", "_version.py"]
+
+# https://google.github.io/pytype/
+[tool.pytype]
+# Space-separated list of files or directories to exclude.
+exclude = [
+    'versioneer.py',
+    '_version.py',
+    '**/_version.py',
+]
+# Space-separated list of files or directories to process.
+inputs = [
+    'monai',
+]
+# Keep going past errors to analyze as many files as possible.
+keep_going = true
+# Run N jobs in parallel. When 'auto' is used, this will be equivalent to the
+# number of CPUs on the host system.
+jobs = 8
+# All pytype output goes here.
+output = '.pytype'
+# Platform (e.g., "linux", "win32") that the target code runs on.
+platform = 'linux'
+# Paths to source code directories, separated by ':'.
+pythonpath = '.'
+
+# Always use function return type annotations. This flag is temporary and will
+# be removed once this behavior is enabled by default.
+always_use_return_annotations = false
+
+# Enable parameter count checks for overriding methods. This flag is temporary
+# and will be removed once this behavior is enabled by default.
+overriding_parameter_count_checks = false
+
+# Enable return type checks for overriding methods. This flag is temporary and
+# will be removed once this behavior is enabled by default.
+overriding_return_type_checks = true
+
+# Use the enum overlay for more precise enum checking. This flag is temporary
+# and will be removed once this behavior is enabled by default.
+use_enum_overlay = false
+
+# Opt-in: Do not allow Any as a return type.
+no_return_any = false
+
+# Experimental: Support pyglib's @cached.property.
+enable_cached_property = false
+
+# Experimental: Infer precise return types even for invalid function calls.
+precise_return = false
+
+# Experimental: Solve unknown types to label with structural types.
+protocols = false
+
+# Experimental: Only load submodules that are explicitly imported.
+strict_import = false
+
+# Experimental: Enable exhaustive checking of function parameter types.
+strict_parameter_checks = false
+
+# Experimental: Emit errors for comparisons between incompatible primitive
+# types.
+strict_primitive_comparisons = false
+
+# Space-separated list of error names to ignore.
+disable = [
+    'pyi-error',
+    'container-type-mismatch',
+    'attribute-error',
+]
+
+# Don't report errors.
+report_errors = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.21.6
 networkx>=2.4
 colorama>=0.4.1
-typeguard>=2.12.1
+typeguard~=2.12.1

--- a/run
+++ b/run
@@ -619,7 +619,7 @@ pytype_format() {
     local python_version="$(get_python_version)"
 
     pushd "${TOP}" > /dev/null
-    run_command ${MONAI_PY_EXE} -m pytype -j "${num_workers}" --python-version="${python_version}"
+    run_command ${MONAI_PY_EXE} -m pytype -j "${num_workers}" --python-version="${python_version}" "${TOP}"
     result=$?
     popd > /dev/null
 

--- a/run
+++ b/run
@@ -619,7 +619,7 @@ pytype_format() {
     local python_version="$(get_python_version)"
 
     pushd "${TOP}" > /dev/null
-    run_command ${MONAI_PY_EXE} -m pytype -j "${num_workers}" --python-version="${python_version}" "${TOP}"
+    run_command ${MONAI_PY_EXE} -m pytype -j "${num_workers}" --python-version="${python_version}"
     result=$?
     popd > /dev/null
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
     numpy>=1.21.6
     networkx>=2.4
     colorama>=0.4.1
-    typeguard>=2.12.1
+    typeguard~=2.12.1
 
 [options.extras_require]
 all =

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ per_file_ignores =
     # 30 warnings with N802 in dicom_study.py
     dicom_study.py: N802
     dicom_series.py:N802
-exclude = *.pyi,.git,.eggs,monai/deploy/_version.py,dist,versioneer.py,venv,.venv,_version.py, monai/deploy/core/graphs/nx_digraph.py, monai/deploy/core/executors/single_process_executor.py
+exclude = *.pyi,.git,.eggs,monai/deploy/_version.py,dist,versioneer.py,venv,.venv,_version.py,monai/deploy/core/graphs/nx_digraph.py,monai/deploy/core/executors/single_process_executor.py
 
 [isort]
 known_first_party = monai

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ per_file_ignores =
     # 30 warnings with N802 in dicom_study.py
     dicom_study.py: N802
     dicom_series.py:N802
-exclude = *.pyi,.git,.eggs,monai/deploy/_version.py,dist,versioneer.py,venv,.venv,_version.py
+exclude = *.pyi,.git,.eggs,monai/deploy/_version.py,dist,versioneer.py,venv,.venv,_version.py, nx_digraph.py, single_process_executor.py
 
 [isort]
 known_first_party = monai

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ per_file_ignores =
     # 30 warnings with N802 in dicom_study.py
     dicom_study.py: N802
     dicom_series.py:N802
-exclude = *.pyi,.git,.eggs,monai/deploy/_version.py,dist,versioneer.py,venv,.venv,_version.py,monai/deploy/core/graphs/nx_digraph.py,monai/deploy/core/executors/single_process_executor.py
+exclude = *.pyi,.git,.eggs,monai/deploy/_version.py,dist,versioneer.py,venv,.venv,_version.py
 
 [isort]
 known_first_party = monai

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ per_file_ignores =
     # 30 warnings with N802 in dicom_study.py
     dicom_study.py: N802
     dicom_series.py:N802
-exclude = *.pyi,.git,.eggs,monai/deploy/_version.py,dist,versioneer.py,venv,.venv,_version.py, nx_digraph.py, single_process_executor.py
+exclude = *.pyi,.git,.eggs,monai/deploy/_version.py,dist,versioneer.py,venv,.venv,_version.py, monai/deploy/core/graphs/nx_digraph.py, monai/deploy/core/executors/single_process_executor.py
 
 [isort]
 known_first_party = monai

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,8 +43,13 @@ ignore =
     E203,E305,E402,E501,E721,E741,F821,F841,F999,W503,W504,C408,E302,W291,E303,
     # N812 lowercase 'torch.nn.functional' imported as non lowercase 'F'
     N812,
-    B024, #abstract base class, but it has no abstract methods
-    B027  #method in base class with no implementation
+    #B024, abstract base class, but it has no abstract methods
+    B024,
+    # B027, #method in base class with no implementation
+    B027,
+    # B905 `zip()` without an explicit `strict=` parameter, but conflicting with pytype
+    B905
+
 per_file_ignores =
     __init__.py: F401
     # Allow using camel case for variable/argument names for the sake of readability.
@@ -104,38 +109,6 @@ ignore_errors = True
 [mypy-monai.eggs]
 # Ignores all non-fatal errors.
 ignore_errors = True
-
-[pytype]
-# Space-separated list of files or directories to exclude.
-exclude = versioneer.py _version.py
-# Space-separated list of files or directories to process.
-inputs = monai
-# Keep going past errors to analyze as many files as possible.
-keep_going = True
-# Run N jobs in parallel.
-jobs = 8
-# All pytype output goes here.
-output = .pytype
-# Paths to source code directories, separated by ':'.
-pythonpath = .
-# Check attribute values against their annotations.
-check_attribute_types = True
-# Check container mutations against their annotations.
-check_container_types = True
-# Check parameter defaults and assignments against their annotations.
-check_parameter_types = True
-# Check variable values against their annotations.
-check_variable_types = True
-# Comma or space separated list of error names to ignore.
-disable = pyi-error
-# Report errors.
-report_errors = True
-# Experimental: Infer precise return types even for invalid function calls.
-precise_return = True
-# Experimental: solve unknown types to label with structural types.
-protocols = True
-# Experimental: Only load submodules that are explicitly imported.
-strict_import = False
 
 [tool:pytest]
 # If a pytest section is found in one of the possible config files


### PR DESCRIPTION
This PR is intended to only change the version of typeguard to ~=2.12.1 (which is equivalent "typeguard>=2.12.1, <3") in the requirements file as well as the Jupyter Notebooks, as it had been discovered that the newer v3 caused application runtime issues when validating the IO_context. Limiting the typeguard version to below 3 avoids the false error, and is used as the solution for the time being while the App SDK is migrated.

However, more files had to be updated, not related to the intended changes but more to resolve the complaints from the newer versions of Flake8, pytype, and mypy,
- the existing setup.cfg is not compatible with the latest pytype, v2023.03.13, with one symptom being the inputs could not be parsed out by pytype. So, new config was regenerated and added to pyproject.toml, as the newer pytype has added support for it
- Flake8 complained about `B905 `zip()` without an explicit `strict=` parameter,` but this is conflicting with pytype and mytype. So, this B905 is ignored in Flake8 settings
- pytype complained about `File "/home/mqin/src/monai-deploy-app-sdk/monai/deploy/core/application.py", line 222, in add_flow: New container type for io_maps does not match type annotation [container-type-mismatch]`, and this error is ignored in the pytype settings because the App SDK will stop using these class when migrated, and, there was no runtime errors
- pytype complained about `File "/home/mqin/src/monai-deploy-app-sdk/monai/deploy/operators/dicom_series_to_volume_operator.py", line 229, in prepare_series: No attribute 'first_pixel_on_slice_normal' on monai.deploy.core.domain.dicom_sop_instance.DICOMSOPInstance [attribute-error]`. This error is ignored for now, and a new [bug ](https://github.com/Project-MONAI/monai-deploy-app-sdk/issues/413) has been created for it

With the change and editable App SDK, verified that the newly built MONAI App Package (docker) indeed has the correctly typeguard version 2.12.1 (not 3.0.1 as reported in the issue)

Also tested the Jupyter notebook and verified the all steps executed successful (e.g. running as script, with `exec` command, with `package` and `run` command).