### PR TITLE
Fix broken links in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,24 +64,24 @@ monai-deploy run simple_app:latest input output
 
 Tutorials are provided to help getting started with the App SDK, to name but a few below.
 
-#### [1) Creating a simple image processing app](https://docs.monai.io/projects/monai-deploy-app-sdk/en/latest/getting_started/tutorials/01_simple_app.html)
+#### [1) Creating a simple image processing app](https://docs.monai.io/projects/monai-deploy-app-sdk/en/latest/getting_started/tutorials/simple_app.html)
 
-#### [2) Creating MedNIST Classifier app](https://docs.monai.io/projects/monai-deploy-app-sdk/en/latest/getting_started/tutorials/02_mednist_app.html)
+#### [2) Creating MedNIST Classifier app](https://docs.monai.io/projects/monai-deploy-app-sdk/en/latest/getting_started/tutorials/mednist_app.html)
 
 YouTube Video:
 
 - [MedNIST Classification Example](https://www.youtube.com/watch?v=WwjilJFHuU4)
 
-### [3) Creating a Segmentation app](https://docs.monai.io/projects/monai-deploy-app-sdk/en/latest/getting_started/tutorials/03_segmentation_app.html)
+### [3) Creating a Segmentation app](https://docs.monai.io/projects/monai-deploy-app-sdk/en/latest/getting_started/tutorials/segmentation_app.html)
 
 YouTube Video:
 
 - [Spleen Organ Segmentation - Jupyter Notebook Tutorial](https://www.youtube.com/watch?v=cqDVxzYt9lY)
 - [Spleen Organ Segmentation - Deep Dive](https://www.youtube.com/watch?v=nivgfD4pwWE)
 
-### [4) Creating a Segmentation app](https://docs.monai.io/projects/monai-deploy-app-sdk/en/latest/getting_started/tutorials/03_segmentation_viz_app.html)
+### [4) Creating a Segmentation app with Clara Viz](https://docs.monai.io/projects/monai-deploy-app-sdk/en/latest/getting_started/tutorials/segmentation_clara-viz_app.html)
 
-### [5) Creating a Segmentation app consuming a MONAI Bundle](https://docs.monai.io/projects/monai-deploy-app-sdk/en/latest/getting_started/tutorials/06_monai_bundle_app.html)
+### [5) Creating a Segmentation app consuming a MONAI Bundle](https://docs.monai.io/projects/monai-deploy-app-sdk/en/latest/getting_started/tutorials/monai_bundle_app.html)
 
 ### [Examples](https://docs.monai.io/projects/monai-deploy-app-sdk/en/latest/getting_started/examples.html)
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ YouTube Video:
 - [Spleen Organ Segmentation - Jupyter Notebook Tutorial](https://www.youtube.com/watch?v=cqDVxzYt9lY)
 - [Spleen Organ Segmentation - Deep Dive](https://www.youtube.com/watch?v=nivgfD4pwWE)
 
-### [4) Creating a Segmentation app with Clara Viz](https://docs.monai.io/projects/monai-deploy-app-sdk/en/latest/getting_started/tutorials/segmentation_clara-viz_app.html)
+### [4) Creating a Segmentation app including visualization with Clara Viz](https://docs.monai.io/projects/monai-deploy-app-sdk/en/latest/getting_started/tutorials/segmentation_clara-viz_app.html)
 
 ### [5) Creating a Segmentation app consuming a MONAI Bundle](https://docs.monai.io/projects/monai-deploy-app-sdk/en/latest/getting_started/tutorials/monai_bundle_app.html)
 


### PR DESCRIPTION
Some links are broken due to the change of sample app name (removal of the numeral prefix).