### PR TITLE
Fixes Project-MONAI/monai-deploy-app-sdk#433

### DIFF
--- a/monai/deploy/utils/importutil.py
+++ b/monai/deploy/utils/importutil.py
@@ -114,7 +114,7 @@ def get_class_file_path(cls: Type) -> Path:
 
     try:
         return Path(inspect.getfile(cls))
-    except TypeError:
+    except (TypeError, OSError):
         # If in IPython shell, use inspect.stack() to get the caller's file path
         stack = inspect.stack()
         for frame in stack:


### PR DESCRIPTION
A fix to handle a change in python 3.10 for the inspect.getfile function. It now returns an `OSError: source code not available`



