### PR TITLE
Update Read The Docs configuration to support Python 3.8

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -25,4 +25,4 @@ python:
 
 
 build:
-  image: stable
+  image: latest

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,28 +1,35 @@
-# .readthedocs.yml
-# Read the Docs configuration file
+# Read the Docs configuration file for Sphinx projects
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
 # Required
 version: 2
 
-# Build documentation in the docs/ directory with Sphinx
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+    # You can also specify other tool versions:
+    # nodejs: "20"
+    # rust: "1.70"
+    # golang: "1.20"
+
+# Build documentation in the "docs/" directory with Sphinx
 sphinx:
   configuration: docs/source/conf.py
-
-# Build documentation with MkDocs
-#mkdocs:
-#  configuration: mkdocs.yml
+  # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
+  # builder: "dirhtml"
+  # Fail on all warnings to avoid broken references
+  # fail_on_warning: true
 
 # Optionally build your docs in additional formats such as PDF and ePub
-# formats: all
+# formats:
+#    - pdf
+#    - epub
 
-# Optionally set the version of Python and requirements required to build your docs
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
-  version: "3.8"
-  install:
-    - requirements: docs/requirements.txt
-#  system_packages: true
-
-
-build:
-  image: latest
+   install:
+   - requirements: docs/requirements.txt


### PR DESCRIPTION
`stable` image doesn't support Python 3.8, causing the following issue.

```
Problem in your project's configuration. Invalid "python.version": expected one of (2, 2.7, 3, 3.5, 3.6, 3.7, pypy3.5), got 3.8
```

https://docs.readthedocs.io/en/stable/config-file/v2.html#build-image-legacy

![image](https://github.com/Project-MONAI/monai-deploy-app-sdk/assets/1928522/351808d0-5b65-43a7-9034-9229d8bbe6cb)

And looks like we are using the old configuration.

This PR updates the configuration to use the latest syntax.
