### PR TITLE
WIP: merge the missed "Bump version: 0.5.0 → 0.5.1" changes to main from v0.5

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.0
+current_version = 0.5.1
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<release>a|b|rc)(?P<build>\d+))?
 serialize = 
 	{major}.{minor}.{patch}{release}{build}

--- a/docs/source/getting_started/installing_app_sdk.md
+++ b/docs/source/getting_started/installing_app_sdk.md
@@ -2,7 +2,7 @@
 
 MONAI Deploy App SDK is available as a Python package through [Python Package Index (PyPI)](https://pypi.org/project/monai-deploy-app-sdk/).
 
-MONAI Deploy App SDK's core functionality is written in Python 3 (>= 3.7) for Linux.
+MONAI Deploy App SDK's core functionality is written in Python 3 (>= 3.8) for Linux.
 
 ```bash
 pip install monai-deploy-app-sdk

--- a/docs/source/getting_started/tutorials/mednist_app.md
+++ b/docs/source/getting_started/tutorials/mednist_app.md
@@ -5,11 +5,11 @@ This tutorial demos the process of packaging up a trained model using MONAI Depl
 ## Setup
 
 ```bash
-# Create a virtual environment with Python 3.7.
+# Create a virtual environment with Python 3.8.
 # Skip if you are already in a virtual environment.
 # (JupyterLab dropped its support for Python 3.6 since 2021-12-23.
 #  See https://github.com/jupyterlab/jupyterlab/pull/11740)
-conda create -n mednist python=3.7 pytorch jupyterlab cudatoolkit=11.1 -c pytorch -c conda-forge
+conda create -n mednist python=3.8 pytorch jupyterlab cudatoolkit=11.1 -c pytorch -c conda-forge
 conda activate mednist
 
 # Launch JupyterLab if you want to work on Jupyter Notebook

--- a/docs/source/getting_started/tutorials/monai_bundle_app.md
+++ b/docs/source/getting_started/tutorials/monai_bundle_app.md
@@ -5,11 +5,11 @@ This tutorial shows how to create an organ segmentation application for a PyTorc
 ## Setup
 
 ```bash
-# Create a virtual environment with Python 3.7.
+# Create a virtual environment with Python 3.8.
 # Skip if you are already in a virtual environment.
 # (JupyterLab dropped its support for Python 3.6 since 2021-12-23.
 #  See https://github.com/jupyterlab/jupyterlab/pull/11740)
-conda create -n monai python=3.7 pytorch torchvision jupyterlab cudatoolkit=11.1 -c pytorch -c conda-forge
+conda create -n monai python=3.8 pytorch torchvision jupyterlab cudatoolkit=11.1 -c pytorch -c conda-forge
 conda activate monai
 
 # Launch JupyterLab if you want to work on Jupyter Notebook

--- a/docs/source/getting_started/tutorials/segmentation_app.md
+++ b/docs/source/getting_started/tutorials/segmentation_app.md
@@ -5,11 +5,11 @@ This tutorial shows how to create an organ segmentation application for a PyTorc
 ## Setup
 
 ```bash
-# Create a virtual environment with Python 3.7.
+# Create a virtual environment with Python 3.8.
 # Skip if you are already in a virtual environment.
 # (JupyterLab dropped its support for Python 3.6 since 2021-12-23.
 #  See https://github.com/jupyterlab/jupyterlab/pull/11740)
-conda create -n monai python=3.7 pytorch torchvision jupyterlab cudatoolkit=11.1 -c pytorch -c conda-forge
+conda create -n monai python=3.8 pytorch torchvision jupyterlab cudatoolkit=11.1 -c pytorch -c conda-forge
 conda activate monai
 
 # Launch JupyterLab if you want to work on Jupyter Notebook

--- a/docs/source/getting_started/tutorials/segmentation_clara-viz_app.md
+++ b/docs/source/getting_started/tutorials/segmentation_clara-viz_app.md
@@ -5,11 +5,11 @@ This tutorial shows how to create an organ segmentation application for a PyTorc
 ## Setup
 
 ```bash
-# Create a virtual environment with Python 3.7.
+# Create a virtual environment with Python 3.8.
 # Skip if you are already in a virtual environment.
 # (JupyterLab dropped its support for Python 3.6 since 2021-12-23.
 #  See https://github.com/jupyterlab/jupyterlab/pull/11740)
-conda create -n monai python=3.7 pytorch torchvision jupyterlab cudatoolkit=11.1 -c pytorch -c conda-forge
+conda create -n monai python=3.8 pytorch torchvision jupyterlab cudatoolkit=11.1 -c pytorch -c conda-forge
 conda activate monai
 
 # Launch JupyterLab if you want to work on Jupyter Notebook

--- a/docs/source/getting_started/tutorials/simple_app.md
+++ b/docs/source/getting_started/tutorials/simple_app.md
@@ -5,11 +5,11 @@ This tutorial shows how to develop a simple image processing application can be 
 ## Setup
 
 ```bash
-# Create a virtual environment with Python 3.7.
+# Create a virtual environment with Python 3.8.
 # Skip if you are already in a virtual environment.
 # (JupyterLab dropped its support for Python 3.6 since 2021-12-23.
 #  See https://github.com/jupyterlab/jupyterlab/pull/11740)
-conda create -n monai python=3.7 pytorch torchvision jupyterlab cudatoolkit=11.1 -c pytorch -c conda-forge
+conda create -n monai python=3.8 pytorch torchvision jupyterlab cudatoolkit=11.1 -c pytorch -c conda-forge
 conda activate monai
 
 # Launch JupyterLab if you want to work on Jupyter Notebook

--- a/docs/source/release_notes/index.md
+++ b/docs/source/release_notes/index.md
@@ -10,6 +10,7 @@
 ```{toctree}
 :maxdepth: 1
 
+v0.5.1
 v0.5.0
 ```
 ## Version 0.4

--- a/docs/source/release_notes/v0.5.1.md
+++ b/docs/source/release_notes/v0.5.1.md
@@ -1,0 +1,42 @@
+# Version 0.5.1 (July 12, 2023)
+
+This is a patch release of [v0.5](https://docs.monai.io/projects/monai-deploy-app-sdk/en/stable/release_notes/v0.5.0.html#), to address compatibility
+issues with newer versions of dependent packages, as well as adding enhancements to built-in operators.
+
+## What's new
+
+- Starting with this release, support [typeguard](https://typeguard.readthedocs.io/en/latest/) v3.0.0 and above
+    - typeguard v3.0.0 introduced breaking changes in its API, causing failure in the App SDK v0.5 since it was implemented using earlier versions
+    - work-around with pinning the typeguard version to v2 must be removed in the applications' dependency requirements
+- Python 3.8 and above are now required
+- Enhancement to support running Jupyter Notebooks with Python 3.10
+- New NIfTI data loader operator
+- Enhancements to inference operator, DICOM Seg Writer operator, CLI Packager, and more, see details below
+
+## What's fixed/updated
+
+- Update SDK to support typeguard v3.0 and above, [#438](https://github.com/Project-MONAI/monai-deploy-app-sdk/pull/438) by MMelQin
+- Fixes Project-MONAI/monai-deploy-app-sdk: running Jupyter notebooks with Python 3.10, [#436](https://github.com/Project-MONAI/monai-deploy-app-sdk/pull/436) by filipmu
+- Updated the MEDNIST tutorial notebooks by adding the dependencies of pydicom and highdicom, [#435](https://github.com/Project-MONAI/monai-deploy-app-sdk/pull/435) by MMelQin
+- Added option for SimpleInferer for the monai_seg_inference_operator, [#428](https://github.com/Project-MONAI/monai-deploy-app-sdk/pull/428) by vikashg
+- [Interim and obsoleted]Fix issue 410 where the latest typeguard version 3.x is incompatible, [#411](https://github.com/Project-MONAI/monai-deploy-app-sdk/pull/411) by MMelQin
+- Enable AMD GPU [via the base image passed to the Packager], [#406](https://github.com/Project-MONAI/monai-deploy-app-sdk/pull/406) by vickytsang
+- Expose option to omit empty frames, enhancement for the DICOM Seg Writer, [#401](https://github.com/Project-MONAI/monai-deploy-app-sdk/pull/401) by CPBridge
+- Add london_aicentre_aide README, [#398](https://github.com/Project-MONAI/monai-deploy-app-sdk/pull/398) by hshuaib90
+- Make the output DICOM SR instance part of the original study, enhancement, [#394](https://github.com/Project-MONAI/monai-deploy-app-sdk/pull/394) by MMelQin
+- Update README.md, [#391](https://github.com/Project-MONAI/monai-deploy-app-sdk/pull/391) by dbericat
+- Fix runtime error for MAP of breast density classification app, [#387](https://github.com/Project-MONAI/monai-deploy-app-sdk/pull/387) by MMelQin
+- ENH: Versions as strings, not numbers, so that 3.1 != 3.10, etc., [#385](https://github.com/Project-MONAI/monai-deploy-app-sdk/pull/385) by Leengit
+- A breast density monai application package, [#384](https://github.com/Project-MONAI/monai-deploy-app-sdk/pull/384) by vikashg
+- Enhance Packager to make the MAP more secure, easier to use, and based on new version of PyTorch image for newer CUDA versions, [#381](https://github.com/Project-MONAI/monai-deploy-app-sdk/pull/381) by MMelQin
+- Fix app requirements to working version, [#380](https://github.com/Project-MONAI/monai-deploy-app-sdk/pull/380) by aihsani
+- Enhanced code to extract and parse specific config files from TorchScript archive, [#378](https://github.com/Project-MONAI/monai-deploy-app-sdk/pull/378) by MMelQin
+- Merge Nuance Updates, [#377](https://github.com/Project-MONAI/monai-deploy-app-sdk/pull/377) by iain-henderson
+- Added a NIfTi data loader for issue #270, [#361](https://github.com/Project-MONAI/monai-deploy-app-sdk/pull/361) by vikashg
+
+## Additional information
+Please visit [GETTING STARTED](/getting_started/index) guide and follow the tutorials.
+
+You can learn more about SDK usage through [DEVELOPING WITH SDK](/developing_with_sdk/index).
+
+Please let us know how you like it and what could be improved by [submitting an issue](https://github.com/Project-MONAI/monai-deploy-app-sdk/issues/new/choose) or [asking questions](https://github.com/Project-MONAI/monai-deploy-app-sdk/discussions)


### PR DESCRIPTION
Some error happened during releasing v0.5.1, so the release note and related doc changes did not get committed back to main, and the v0.5 is one commit ahead of main.

This one is intended to cherry-pick the last commit back to main. 