### PR TITLE
Fixing the now extreme long time to pip install during gen doc, causing timeout failure on readthedoc

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,12 +1,11 @@
 Sphinx==4.1.2
 sphinx-autobuild==2021.3.14
-myst-parser==0.15.2
-numpy>=1.21.6
-matplotlib==3.3.4
-ipywidgets==7.6.4
-pandas==1.1.5
-nbclient==0.5.4
-myst-nb==0.13.0
+myst-nb==0.17.2  # this version is fine in python 3.8 and avoids pulling in multiple nbformat packages
+myst-parser==0.18.0
+lxml_html_clean  # needed by myst-nb
+#numpy>=1.21.6
+#matplotlib==3.3.4
+#pandas==1.1.5
 linkify-it-py==1.0.1  # https://myst-parser.readthedocs.io/en/latest/syntax/optional.html?highlight=linkify#linkify
 sphinx-togglebutton==0.2.3
 sphinx-copybutton==0.4.0
@@ -18,17 +17,17 @@ ablog==0.10.19
 docutils==0.16  # 0.17 causes error. https://github.com/executablebooks/MyST-Parser/issues/343
 pydata_sphinx_theme==0.6.3
 sphinxemoji==0.1.8
-scipy
-scikit-image>=0.17.2
-plotly
-nibabel>=3.2.1
-monai>=1.0.0
+#scipy
+#scikit-image>=0.17.2
+#plotly
+#nibabel>=3.2.1
+#monai>=1.0.0
 torch>=1.12.0
-numpy-stl>=2.12.0
-trimesh>=3.8.11
-pydicom
-PyPDF2>=2.11.1
-highdicom>=0.18.2
+#numpy-stl>=2.12.0
+#trimesh>=3.8.11
+#pydicom
+#PyPDF2>=2.11.1
+#highdicom>=0.18.2
 sphinx-autodoc-typehints==1.12.0
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2
@@ -37,4 +36,3 @@ sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
 sphinxcontrib-mermaid==0.7.1
-lxml_html_clean

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,9 +3,6 @@ sphinx-autobuild==2021.3.14
 myst-nb==0.17.2  # this version is fine in python 3.8 and avoids pulling in multiple nbformat packages
 myst-parser==0.18.0
 lxml_html_clean  # needed by myst-nb
-#numpy>=1.21.6
-#matplotlib==3.3.4
-#pandas==1.1.5
 linkify-it-py==1.0.1  # https://myst-parser.readthedocs.io/en/latest/syntax/optional.html?highlight=linkify#linkify
 sphinx-togglebutton==0.2.3
 sphinx-copybutton==0.4.0
@@ -17,17 +14,7 @@ ablog==0.10.19
 docutils==0.16  # 0.17 causes error. https://github.com/executablebooks/MyST-Parser/issues/343
 pydata_sphinx_theme==0.6.3
 sphinxemoji==0.1.8
-#scipy
-#scikit-image>=0.17.2
-#plotly
-#nibabel>=3.2.1
-#monai>=1.0.0
 torch>=1.12.0
-#numpy-stl>=2.12.0
-#trimesh>=3.8.11
-#pydicom
-#PyPDF2>=2.11.1
-#highdicom>=0.18.2
 sphinx-autodoc-typehints==1.12.0
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,13 +19,9 @@ if on_rtd:
         f"{READTHEDOCS_PROJECT}/envs/{READTHEDOCS_VERSION}/bin/activate; ../../run setup read_the_docs'",
         shell=True,
     )
-    # Update LD_LIBRARY_PATH for CUDA runtime
-    old_ld_library_path = os.environ.get("LD_LIBRARY_PATH", "")
-    # Note that 'python3.8' is hard-coded here, it should be updated if the Python version changes by
-    # .readthedocs.yml or other configurations.
-    os.environ["LD_LIBRARY_PATH"] = (
-        f"{READTHEDOCS_PROJECT}/envs/{READTHEDOCS_VERSION}/lib/python3.8/site-packages/nvidia/cuda_runtime/lib:{old_ld_library_path}"
-    )
+    # Print LD_LIBRARY_PATH for verification
+    ld_library_path = os.environ.get("LD_LIBRARY_PATH", "")
+    print(f"LD_LIBRARY_PATH: {ld_library_path}")
     subprocess.call(
         "/bin/bash -c 'source /home/docs/checkouts/readthedocs.org/user_builds/"
         f"{READTHEDOCS_PROJECT}/envs/{READTHEDOCS_VERSION}/bin/activate; ../../run setup_gen_docs'",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,6 +19,13 @@ if on_rtd:
         f"{READTHEDOCS_PROJECT}/envs/{READTHEDOCS_VERSION}/bin/activate; ../../run setup read_the_docs'",
         shell=True,
     )
+    # Update LD_LIBRARY_PATH for CUDA runtime
+    old_ld_library_path = os.environ.get("LD_LIBRARY_PATH", "")
+    # Note that 'python3.8' is hard-coded here, it should be updated if the Python version changes by
+    # .readthedocs.yml or other configurations.
+    os.environ["LD_LIBRARY_PATH"] = (
+        f"{READTHEDOCS_PROJECT}/envs/{READTHEDOCS_VERSION}/lib/python3.8/site-packages/nvidia/cuda_runtime/lib:{old_ld_library_path}"
+    )
     subprocess.call(
         "/bin/bash -c 'source /home/docs/checkouts/readthedocs.org/user_builds/"
         f"{READTHEDOCS_PROJECT}/envs/{READTHEDOCS_VERSION}/bin/activate; ../../run setup_gen_docs'",

--- a/run
+++ b/run
@@ -302,12 +302,11 @@ get_package_info() {
 
 install_python_dev_deps() {
     local config="${1:-dev}"
+    local is_read_the_docs="false"
     if [ -n "${VIRTUAL_ENV}" ] || [ -n "${CONDA_PREFIX}" ]; then
         # Read the Docs site is using specific setuptools version so should not upgrade it.
         if [ "$config" = "read_the_docs" ]; then
-            run_command ${MONAI_PY_EXE} -m pip install -q -U pip wheel build
-            # Install cuda runtime dependency
-            run_command ${MONAI_PY_EXE} -m pip install -q nvidia-cuda-runtime-cu12
+            is_read_the_docs="true"
         else
             run_command ${MONAI_PY_EXE} -m pip install -q -U setuptools pip wheel build
         fi
@@ -331,6 +330,26 @@ install_python_dev_deps() {
     # fix_holoscan_import
 
     install_edit_mode
+
+    # Install packages overridden by Holoscan package if readthedocs is enabled
+    if [ ${is_read_the_docs} = "true" ]; then
+        # Upgrade pip overridden by Holoscan
+        run_command ${MONAI_PY_EXE} -m pip install -q -U pip wheel build
+        # Upgrade PyYAML to avoid the issue with the version installed by Holoscan
+        run_command ${MONAI_PY_EXE} -m pip install -U PyYAML
+
+        # Install cuda runtime dependency
+        run_command ${MONAI_PY_EXE} -m pip install nvidia-cuda-runtime-cu12
+
+        # Copy the cuda runtime library to the fixed location (workaround for readthedocs) so that
+        # we can leverage the existing LD_LIBRARY_PATH (configured by the readthedocs UI) to locate the cuda runtime library.
+        # (LD_LIBRARY_PATH is set to /home/docs/ for that purpose)
+        # Note that 'python3.8' is hard-coded here, it should be updated if the Python version changes by
+        # .readthedocs.yml or other configurations.
+        run_command ls -al /home/docs/checkouts/readthedocs.org/user_builds/${READTHEDOCS_PROJECT}/envs/${READTHEDOCS_VERSION}/lib/python3.8/site-packages/nvidia/cuda_runtime/lib/
+        run_command cp /home/docs/checkouts/readthedocs.org/user_builds/${READTHEDOCS_PROJECT}/envs/${READTHEDOCS_VERSION}/lib/python3.8/site-packages/nvidia/cuda_runtime/lib/*.so* /home/docs/
+        run_command ls -al /home/docs/
+    fi
 }
 
 fix_holoscan_import() {

--- a/run
+++ b/run
@@ -306,6 +306,8 @@ install_python_dev_deps() {
         # Read the Docs site is using specific setuptools version so should not upgrade it.
         if [ "$config" = "read_the_docs" ]; then
             run_command ${MONAI_PY_EXE} -m pip install -q -U pip wheel build
+            # Install cuda runtime dependency
+            run_command ${MONAI_PY_EXE} -m pip install -q nvidia-cuda-runtime-cu12
         else
             run_command ${MONAI_PY_EXE} -m pip install -q -U setuptools pip wheel build
         fi


### PR DESCRIPTION
It has been observed that gen doc takes a very long time to install multiple versions of nbformat, both locally and on readthedocs, on the latter the [build fails](https://readthedocs.org/projects/monai-deploy-app-sdk/builds/24041688/) due to 30 mins timeout.

It has been identified that the older the few Jupyter notebook related packages, with their older version for Python 3.8, strangely caused multiple versions of nbformat to be installed.

Removing the most Jupyter notebook related packages, except for myst-nb with newer version, reduced the gen doc time dramatically.  

Removing App Sdk, example app and jupyter notebook requirments also further reduced the doc build time and has no impact on final doc.
