### PR TITLE
DICOMSeriesToVolumeOperator Slice Removal Fix

### DIFF
--- a/monai/deploy/operators/dicom_series_to_volume_operator.py
+++ b/monai/deploy/operators/dicom_series_to_volume_operator.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2023 MONAI Consortium
+# Copyright 2021-2025 MONAI Consortium
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -234,11 +234,17 @@ class DICOMSeriesToVolumeOperator(Operator):
                 series._sop_instances[slice_index].distance = distance
                 series._sop_instances[slice_index].first_pixel_on_slice_normal = point
             else:
-                print("going to removing slice ", slice_index)
+                logging.debug(f"Slice index to remove: {slice_index}")
                 slice_indices_to_be_removed.append(slice_index)
 
-        for sl_index, _ in enumerate(slice_indices_to_be_removed):
+        logging.debug(f"Total slices before removal (if applicable): {len(series._sop_instances)}")
+
+        # iterate in reverse order to avoid affecting subsequent indices after a deletion
+        for sl_index in sorted(slice_indices_to_be_removed, reverse=True):
             del series._sop_instances[sl_index]
+            logging.info(f"Removed slice index: {sl_index}")
+
+        logging.debug(f"Total slices after removal (if applicable): {len(series._sop_instances)}")
 
         series._sop_instances = sorted(series._sop_instances, key=lambda s: s.distance)
         series.depth_direction_cosine = copy.deepcopy(last_slice_normal)


### PR DESCRIPTION
I discovered that the `DICOMSeriesToVolumeOperator` does not correctly handle slice removal within the `prepare_series` method.

I tested with an axial MRI series that has a single, non-image DICOM file (`ImageOrientationPatient` and `ImagePositionPatient` tags are absent). This method is built to handle cases like this and remove the slice prior to volume conversion; however, I discovered the removal process is incorrect. Below is a terminal output when testing the current operator (I added in a few logs for debugging):

```bash
WARNING:root:No selection rules given; select all series.
Slice index to remove:  40
Total slices before removal: 63
Removed slice index:  0
Total slices after removal: 62
Traceback (most recent call last):
  File "/home/bluna301/monai-deploy-app-sdk/monai/deploy/operators/dicom_series_to_volume_operator.py", line 442, in <module>
    test()
  File "/home/bluna301/monai-deploy-app-sdk/monai/deploy/operators/dicom_series_to_volume_operator.py", line 434, in test
    image = vol_op.convert_to_image(study_selected_series_list)
  File "/home/bluna301/monai-deploy-app-sdk/monai/deploy/operators/dicom_series_to_volume_operator.py", line 75, in convert_to_image
    self.prepare_series(dicom_series)
  File "/home/bluna301/monai-deploy-app-sdk/monai/deploy/operators/dicom_series_to_volume_operator.py", line 250, in prepare_series
    series._sop_instances = sorted(series._sop_instances, key=lambda s: s.distance)
  File "/home/bluna301/monai-deploy-app-sdk/monai/deploy/operators/dicom_series_to_volume_operator.py", line 250, in <lambda>
    series._sop_instances = sorted(series._sop_instances, key=lambda s: s.distance)
AttributeError: 'DICOMSOPInstance' object has no attribute 'distance'
```

Slice removal is occurring (total # of slices drops by 1), but the wrong slice is being removed; thus, the non-image DICOM file is still present and causes the error. The current removal functionality (below)  iterates over indices of `slice_indices_to_be_removed`, not the actual slice indices stored in the list (i.e. the actual slice indices of `series._sop_instances`). This explains why slice 0 is being removed (1 element in list = 0th index).

```python
for sl_index, _ in enumerate(slice_indices_to_be_removed):
     del series._sop_instances[sl_index]
```

My fix is to iterate over a sorted `slice_indices_to_be_removed` in reverse order and pull out the slice index to delete; sorting in reverse order will allow us to remove slices without having to worry about reindexing. Below is the terminal output with the fixes implemented (slice index to remove = removed slice index):

```bash
WARNING:root:No selection rules given; select all series.
Slice index to remove:  40
Total slices before removal: 63
Removed slice index:  40
Total slices after removal: 62
The (0028,0101) 'Bits Stored' value (12-bit) doesn't match the JPEG 2000 data (9-bit). It's recommended that you change the 'Bits Stored' value
The (0028,0101) 'Bits Stored' value (12-bit) doesn't match the JPEG 2000 data (10-bit). It's recommended that you change the 'Bits Stored' value
Image NumPy array shape (index order DHW): (62, 432, 432)
SeriesInstanceUID: REDACTED
Modality: MR
SeriesDescription: REDACTED
PatientPosition: REDACTED
SeriesNumber: REDACTED
row_pixel_spacing: 0.78703701496124
col_pixel_spacing: 0.78703701496124
depth_pixel_spacing: 5.0
row_direction_cosine: [1.0, 0.0, 0.0]
col_direction_cosine: [0.0, 1.0, 0.0]
depth_direction_cosine: [0.0, 0.0, 1.0]
dicom_affine_transform: [[   0.78703701    0.            0.         -172.00736088]
 [   0.            0.78703701    0.         -178.60647672]
 [   0.            0.            5.         -158.39006042]
 [   0.            0.            0.            1.        ]]
nifti_affine_transform: [[  -0.78703701   -0.           -0.          172.00736088]
 [  -0.           -0.78703701   -0.          178.60647672]
 [   0.            0.            5.         -158.39006042]
 [   0.            0.            0.            1.        ]]
StudyInstanceUID: REDACTED
StudyID: 
StudyDate: 
StudyTime: 
StudyDescription: REDACTED
AccessionNumber: 
```

I think we should make the slice removal confirmation an `info` log so that users have some feedback that this removal occurred. Take it or leave it on the `debug` logs (would be fine removing the total slice # logs all together), will defer to your guidance here.