### PR TITLE
Fix DICOMSeriesToVolumeOperator casting bug

### DIFF
--- a/monai/deploy/operators/dicom_series_to_volume_operator.py
+++ b/monai/deploy/operators/dicom_series_to_volume_operator.py
@@ -112,7 +112,7 @@ class DICOMSeriesToVolumeOperator(Operator):
         # with the NumPy array returned from the ITK GetArrayViewFromImage on the image
         # loaded from the same DICOM series.
         vol_data = np.stack([s.get_pixel_array() for s in slices], axis=0)
-        vol_data = vol_data.astype(np.int16)
+        vol_data = vol_data.astype(np.uint16)
 
         # For now we support monochrome image only, for which DICOM Photometric Interpretation
         # (0028,0004) has defined terms, MONOCHROME1 and MONOCHROME2, with the former being:
@@ -156,9 +156,14 @@ class DICOMSeriesToVolumeOperator(Operator):
 
         if slope != 1:
             vol_data = slope * vol_data.astype(np.float64)
-            vol_data = vol_data.astype(np.int16)
-        vol_data += np.int16(intercept)
-        return np.array(vol_data, dtype=np.int16)
+        vol_data += intercept
+
+        # Check if vol_data can be cast to uint16 without data loss
+        if np.can_cast(vol_data, np.uint16, casting='safe'):
+            vol_data = np.array(vol_data, dtype=np.uint16)
+        else:
+            vol_data = np.array(vol_data, dtype=np.int32)
+        return vol_data
 
     def create_volumetric_image(self, vox_data, metadata):
         """Creates an instance of 3D image.

--- a/monai/deploy/operators/dicom_series_to_volume_operator.py
+++ b/monai/deploy/operators/dicom_series_to_volume_operator.py
@@ -155,17 +155,28 @@ class DICOMSeriesToVolumeOperator(Operator):
         except KeyError:
             slope = 1
 
-        if slope != 1:
-            vol_data = slope * vol_data.astype(np.float64)
-        vol_data += intercept
 
-        # Check if vol_data can be cast to uint16 without data loss
-        if np.can_cast(vol_data, np.uint16, casting='safe'):
+        # check if vol_data, intercept, and slope can be cast to uint16 without data loss
+        if np.can_cast(vol_data, np.uint16, casting='safe') and np.can_cast(intercept, np.uint16, casting='safe') and np.can_cast(slope, np.uint16, casting='safe'):
+            logging.info(f"Casting to uint16")
             vol_data = np.array(vol_data, dtype=np.uint16)
-        elif np.can_cast(vol_data, np.float32, casting='safe'):
+            intercept = np.uint16(intercept)
+            slope = np.uint16(slope)
+        elif np.can_cast(vol_data, np.float32, casting='safe') and np.can_cast(intercept, np.float32, casting='safe') and np.can_cast(slope, np.float32, casting='safe'):
+            logging.info(f"Casting to float32")
             vol_data = np.array(vol_data, dtype=np.float32)
-        elif np.can_cast(vol_data, np.float64, casting='safe'):
-            vol_data = np.array(vol_data, dtype=np.float32)
+            intercept = np.float32(intercept)
+            slope = np.float32(slope)
+        elif np.can_cast(vol_data, np.float64, casting='safe') and np.can_cast(intercept, np.float64, casting='safe') and np.can_cast(slope, np.float64, casting='safe'):
+            logging.info(f"Casting to float64")
+            vol_data = np.array(vol_data, dtype=np.float64)
+            intercept = np.float64(intercept)
+            slope = np.float64(slope)
+            
+        if slope != 1:
+            vol_data = slope * vol_data
+
+        vol_data += intercept
         return vol_data
 
     def create_volumetric_image(self, vox_data, metadata):


### PR DESCRIPTION
The array was being read in as int16 which caused some values to be truncated, it should instead be uint16. I also added a check that uint16 is sufficient after the slope/intercept transformation is applied. if it is not, it will use int32 instead. 