### PR TITLE
Support remote inference on Triton Inference Server with ease of use

### DIFF
--- a/docs/source/getting_started/examples.md
+++ b/docs/source/getting_started/examples.md
@@ -14,3 +14,4 @@
 - dicom_series_to_image_app
 - breast_density_classifer_app
 - cchmc_ped_abd_ct_seg_app
+- ai_remote_infer_app

--- a/examples/apps/ai_remote_infer_app/__main__.py
+++ b/examples/apps/ai_remote_infer_app/__main__.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2025 MONAI Consortium
+# Copyright 2025 MONAI Consortium
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/examples/apps/ai_remote_infer_app/__main__.py
+++ b/examples/apps/ai_remote_infer_app/__main__.py
@@ -1,0 +1,15 @@
+# Copyright 2021-2025 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from app import AIRemoteInferSpleenSegApp
+
+if __name__ == "__main__":
+    AIRemoteInferSpleenSegApp().run()

--- a/examples/apps/ai_remote_infer_app/app.py
+++ b/examples/apps/ai_remote_infer_app/app.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2025 MONAI Consortium
+# Copyright 2025 MONAI Consortium
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/examples/apps/ai_remote_infer_app/app.py
+++ b/examples/apps/ai_remote_infer_app/app.py
@@ -1,0 +1,143 @@
+# Copyright 2021-2025 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+from pathlib import Path
+
+from pydicom.sr.codedict import codes  # Required for setting SegmentDescription attributes.
+from spleen_seg_operator import SpleenSegOperator
+
+from monai.deploy.conditions import CountCondition
+from monai.deploy.core import Application
+from monai.deploy.operators.dicom_data_loader_operator import DICOMDataLoaderOperator
+from monai.deploy.operators.dicom_seg_writer_operator import DICOMSegmentationWriterOperator, SegmentDescription
+from monai.deploy.operators.dicom_series_selector_operator import DICOMSeriesSelectorOperator
+from monai.deploy.operators.dicom_series_to_volume_operator import DICOMSeriesToVolumeOperator
+from monai.deploy.operators.stl_conversion_operator import STLConversionOperator
+
+
+class AIRemoteInferSpleenSegApp(Application):
+    def __init__(self, *args, **kwargs):
+        """Creates an application instance."""
+
+        super().__init__(*args, **kwargs)
+        self._logger = logging.getLogger("{}.{}".format(__name__, type(self).__name__))
+
+    def run(self, *args, **kwargs):
+        # This method calls the base class to run. Can be omitted if simply calling through.
+        self._logger.info(f"Begin {self.run.__name__}")
+        super().run(*args, **kwargs)
+        self._logger.info(f"End {self.run.__name__}")
+
+    def compose(self):
+        """Creates the app specific operators and chain them up in the processing DAG."""
+
+        # Use Commandline options over environment variables to init context.
+        app_context = Application.init_app_context(self.argv)
+        self._logger.debug(f"Begin {self.compose.__name__}")
+        app_input_path = Path(app_context.input_path)
+        app_output_path = Path(app_context.output_path)
+        model_path = Path(app_context.model_path)
+
+        self._logger.info(f"App input and output path: {app_input_path}, {app_output_path}")
+
+        # instantiates the SDK built-in operator(s).
+        study_loader_op = DICOMDataLoaderOperator(
+            self, CountCondition(self, 1), input_folder=app_input_path, name="dcm_loader_op"
+        )
+        series_selector_op = DICOMSeriesSelectorOperator(self, rules=Sample_Rules_Text, name="series_selector_op")
+        series_to_vol_op = DICOMSeriesToVolumeOperator(self, name="series_to_vol_op")
+
+        # Model specific inference operator, supporting MONAI transforms.
+        spleen_seg_op = SpleenSegOperator(
+            self, app_context=app_context, model_name="spleen_ct", model_path=model_path, name="seg_op"
+        )
+
+        # Create DICOM Seg writer providing the required segment description for each segment with
+        # the actual algorithm and the pertinent organ/tissue.
+        # The segment_label, algorithm_name, and algorithm_version are limited to 64 chars.
+        # https://dicom.nema.org/medical/dicom/current/output/chtml/part05/sect_6.2.html
+        # User can Look up SNOMED CT codes at, e.g.
+        # https://bioportal.bioontology.org/ontologies/SNOMEDCT
+
+        _algorithm_name = "3D segmentation of the Spleen from a CT series"
+        _algorithm_family = codes.DCM.ArtificialIntelligence
+        _algorithm_version = "0.1.0"
+
+        segment_descriptions = [
+            SegmentDescription(
+                segment_label="Spleen",
+                segmented_property_category=codes.SCT.Organ,
+                segmented_property_type=codes.SCT.Spleen,
+                algorithm_name=_algorithm_name,
+                algorithm_family=_algorithm_family,
+                algorithm_version=_algorithm_version,
+            ),
+        ]
+
+        custom_tags = {"SeriesDescription": "AI generated Seg, not for clinical use."}
+
+        dicom_seg_writer = DICOMSegmentationWriterOperator(
+            self,
+            segment_descriptions=segment_descriptions,
+            custom_tags=custom_tags,
+            output_folder=app_output_path,
+            name="dcm_seg_writer_op",
+        )
+
+        # Create the processing pipeline, by specifying the source and destination operators, and
+        # ensuring the output from the former matches the input of the latter, in both name and type.
+        self.add_flow(study_loader_op, series_selector_op, {("dicom_study_list", "dicom_study_list")})
+        self.add_flow(
+            series_selector_op, series_to_vol_op, {("study_selected_series_list", "study_selected_series_list")}
+        )
+        self.add_flow(series_to_vol_op, spleen_seg_op, {("image", "image")})
+
+        # Note below the dicom_seg_writer requires two inputs, each coming from a source operator.
+        self.add_flow(
+            series_selector_op, dicom_seg_writer, {("study_selected_series_list", "study_selected_series_list")}
+        )
+        self.add_flow(spleen_seg_op, dicom_seg_writer, {("seg_image", "seg_image")})
+
+        # Create the surface mesh STL conversion operator and add it to the app execution flow, if needed, by
+        # uncommenting the following couple lines.
+        stl_conversion_op = STLConversionOperator(
+            self, output_file=app_output_path.joinpath("stl/spleen.stl"), name="stl_conversion_op"
+        )
+        self.add_flow(spleen_seg_op, stl_conversion_op, {("pred", "image")})
+
+        self._logger.debug(f"End {self.compose.__name__}")
+
+
+# This is a sample series selection rule in JSON, simply selecting CT series.
+# If the study has more than 1 CT series, then all of them will be selected.
+# Please see more detail in DICOMSeriesSelectorOperator.
+# For list of string values, e.g. "ImageType": ["PRIMARY", "ORIGINAL"], it is a match if all elements
+# are all in the multi-value attribute of the DICOM series.
+
+Sample_Rules_Text = """
+{
+    "selections": [
+        {
+            "name": "CT Series",
+            "conditions": {
+                "StudyDescription": "(.*?)",
+                "Modality": "(?i)CT",
+                "SeriesDescription": "(.*?)",
+                "ImageType": ["PRIMARY", "ORIGINAL"]
+            }
+        }
+    ]
+}
+"""
+
+if __name__ == "__main__":
+    # Creates the app and test it standalone.
+    AIRemoteInferSpleenSegApp().run()

--- a/examples/apps/ai_remote_infer_app/env_settings_example.sh
+++ b/examples/apps/ai_remote_infer_app/env_settings_example.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+export HOLOSCAN_INPUT_PATH="inputs/spleen_ct_tcia"
+export HOLOSCAN_MODEL_PATH="examples/apps/ai_remote_infer_app/models_client_side"
+export HOLOSCAN_OUTPUT_PATH="output_spleen"
+export HOLOSCAN_LOG_LEVEL=DEBUG  # TRACE can be used for verbose low-level logging
+export TRITON_SERVER_NETLOC="localhost:8000"  # Triton server network location, host:port

--- a/examples/apps/ai_remote_infer_app/env_settings_example.sh
+++ b/examples/apps/ai_remote_infer_app/env_settings_example.sh
@@ -1,3 +1,14 @@
+# Copyright 2025 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #!/bin/bash
 export HOLOSCAN_INPUT_PATH="inputs/spleen_ct_tcia"
 export HOLOSCAN_MODEL_PATH="examples/apps/ai_remote_infer_app/models_client_side"

--- a/examples/apps/ai_remote_infer_app/models_client_side/spleen_ct/config.pbtxt
+++ b/examples/apps/ai_remote_infer_app/models_client_side/spleen_ct/config.pbtxt
@@ -1,0 +1,44 @@
+platform: "pytorch_libtorch"
+
+max_batch_size: 16  # The maximum batch size. 0 for no batching with full shape in dims
+
+default_model_filename: "model_spleen_ct_segmentation_v1.ts"  #  The name of the TorchScript model file
+
+input [
+  {
+    name: "INPUT_0"  # The name of the input tensor (or should match the input tensor name in your model if used)
+    data_type: TYPE_FP32  # Data type is FP32
+    dims: [ 1, 96, 96, 96 ]  # Input dimensions: [channels, width, height, depth], to be stacked as a batch
+  }
+]
+
+output [
+  {
+    name: "OUTPUT_0"  # The name of the output tensor (match this with your TorchScript model's output name)
+    data_type: TYPE_FP32  # Output is FP32
+    dims: [ 2, 96, 96, 96 ]  # Output dimensions: [channels, width, height, depth], stacked to match input batch size
+  }
+]
+
+version_policy: { latest: { num_versions: 1}}  # Only serve the latest version, which is the default
+
+instance_group [
+  {
+    kind: KIND_GPU  # Specify the hardware type (GPU in this case)
+    count: 1  # Number of instances created for each GPU listed in 'gpus' (adjust based on your resources)
+  }
+]
+
+dynamic_batching {
+  preferred_batch_size: [ 4, 8, 16 ]  # Preferred batch size(s) for dynamic batching. Matching the max_batch_size for sync calls.
+  max_queue_delay_microseconds: 1000  # Max delay before processing the batch.
+}
+
+# The initial calls to a loaded TorchScript model take extremely long.
+# Due to this longer model warmup issue, Triton allows execution of models without these optimizations.
+parameters: {
+  key: "DISABLE_OPTIMIZED_EXECUTION"
+  value: {
+    string_value: "true"
+  }
+}

--- a/examples/apps/ai_remote_infer_app/spleen_seg_operator.py
+++ b/examples/apps/ai_remote_infer_app/spleen_seg_operator.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2025 MONAI Consortium
+# Copyright 2025 MONAI Consortium
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/examples/apps/ai_remote_infer_app/spleen_seg_operator.py
+++ b/examples/apps/ai_remote_infer_app/spleen_seg_operator.py
@@ -1,0 +1,165 @@
+# Copyright 2021-2025 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from pathlib import Path
+
+from numpy import uint8
+
+from monai.deploy.core import AppContext, ConditionType, Fragment, Operator, OperatorSpec
+from monai.deploy.operators.monai_seg_inference_operator import InfererType, InMemImageReader, MonaiSegInferenceOperator
+from monai.transforms import (
+    Activationsd,
+    AsDiscreted,
+    Compose,
+    EnsureChannelFirstd,
+    EnsureTyped,
+    Invertd,
+    LoadImaged,
+    Orientationd,
+    SaveImaged,
+    ScaleIntensityRanged,
+    Spacingd,
+)
+
+
+class SpleenSegOperator(Operator):
+    """Performs Spleen segmentation with a 3D image converted from a DICOM CT series."""
+
+    DEFAULT_OUTPUT_FOLDER = Path.cwd() / "output/saved_images_folder"
+
+    def __init__(
+        self,
+        fragment: Fragment,
+        *args,
+        app_context: AppContext,
+        model_path: Path,
+        model_name: str,
+        output_folder: Path = DEFAULT_OUTPUT_FOLDER,
+        **kwargs,
+    ):
+
+        self.logger = logging.getLogger("{}.{}".format(__name__, type(self).__name__))
+        self._input_dataset_key = "image"
+        self._pred_dataset_key = "pred"
+
+        self.model_path = model_path
+        self.model_name = model_name
+        self.output_folder = output_folder
+        self.output_folder.mkdir(parents=True, exist_ok=True)
+        self.app_context = app_context
+        self.input_name_image = "image"
+        self.output_name_seg = "seg_image"
+        self.output_name_saved_images_folder = "saved_images_folder"
+
+        # The base class has an attribute called fragment to hold the reference to the fragment object
+        super().__init__(fragment, *args, **kwargs)
+
+    def setup(self, spec: OperatorSpec):
+        spec.input(self.input_name_image)
+        spec.output(self.output_name_seg)
+        spec.output(self.output_name_saved_images_folder).condition(
+            ConditionType.NONE
+        )  # Output not requiring a receiver
+
+    def compute(self, op_input, op_output, context):
+        input_image = op_input.receive(self.input_name_image)
+        if not input_image:
+            raise ValueError("Input image is not found.")
+
+        # This operator gets an in-memory Image object, so a specialized ImageReader is needed.
+        _reader = InMemImageReader(input_image)
+
+        pre_transforms = self.pre_process(_reader, str(self.output_folder))
+        post_transforms = self.post_process(pre_transforms, str(self.output_folder))
+
+        # Delegates inference and saving output to the built-in operator.
+        infer_operator = MonaiSegInferenceOperator(
+            self.fragment,
+            roi_size=(
+                96,
+                96,
+                96,
+            ),
+            pre_transforms=pre_transforms,
+            post_transforms=post_transforms,
+            overlap=0.6,
+            app_context=self.app_context,
+            model_name=self.model_name,
+            inferer=InfererType.SLIDING_WINDOW,
+            sw_batch_size=4,
+            model_path=self.model_path,
+            name="monai_seg_remote_inference_op",
+        )
+
+        # Setting the keys used in the dictionary based transforms may change.
+        infer_operator.input_dataset_key = self._input_dataset_key
+        infer_operator.pred_dataset_key = self._pred_dataset_key
+
+        # Now emit data to the output ports of this operator
+        op_output.emit(infer_operator.compute_impl(input_image, context), self.output_name_seg)
+        op_output.emit(self.output_folder, self.output_name_saved_images_folder)
+
+    def pre_process(self, img_reader, out_dir: str = "./input_images") -> Compose:
+        """Composes transforms for preprocessing input before predicting on a model."""
+
+        Path(out_dir).mkdir(parents=True, exist_ok=True)
+        my_key = self._input_dataset_key
+
+        return Compose(
+            [
+                LoadImaged(keys=my_key, reader=img_reader),
+                EnsureChannelFirstd(keys=my_key),
+                # The SaveImaged transform can be commented out to save 5 seconds.
+                # Uncompress NIfTI file, nii, is used favoring speed over size, but can be changed to nii.gz
+                SaveImaged(
+                    keys=my_key,
+                    output_dir=out_dir,
+                    output_postfix="",
+                    resample=False,
+                    output_ext=".nii",
+                ),
+                Orientationd(keys=my_key, axcodes="RAS"),
+                Spacingd(keys=my_key, pixdim=[1.5, 1.5, 2.9], mode=["bilinear"]),
+                ScaleIntensityRanged(keys=my_key, a_min=-57, a_max=164, b_min=0.0, b_max=1.0, clip=True),
+                EnsureTyped(keys=my_key),
+            ]
+        )
+
+    def post_process(self, pre_transforms: Compose, out_dir: str = "./prediction_output") -> Compose:
+        """Composes transforms for postprocessing the prediction results."""
+
+        Path(out_dir).mkdir(parents=True, exist_ok=True)
+        pred_key = self._pred_dataset_key
+
+        return Compose(
+            [
+                Activationsd(keys=pred_key, softmax=True),
+                Invertd(
+                    keys=pred_key,
+                    transform=pre_transforms,
+                    orig_keys=self._input_dataset_key,
+                    nearest_interp=False,
+                    to_tensor=True,
+                ),
+                AsDiscreted(keys=pred_key, argmax=True),
+                # The SaveImaged transform can be commented out to save 5 seconds.
+                # Uncompress NIfTI file, nii, is used favoring speed over size, but can be changed to nii.gz
+                SaveImaged(
+                    keys=pred_key,
+                    output_dir=out_dir,
+                    output_postfix="seg",
+                    output_dtype=uint8,
+                    resample=False,
+                    output_ext=".nii",
+                ),
+            ]
+        )

--- a/monai/deploy/core/app_context.py
+++ b/monai/deploy/core/app_context.py
@@ -63,7 +63,7 @@ class AppContext(object):
 
         # TritonModel instances are just clients and must be connected to the Triton Inference Server
         # at the provided network location. In-process hosting of Triton Inference Server is not supported.
-        if self.triton_server_netloc:
+        if self.triton_server_netloc and self.models:
             for _, model in self.models.items():
                 if isinstance(model, TritonModel):
                     model.connect(self.triton_server_netloc, verbose=args.get("log_level", "INFO") == "DEBUG")

--- a/monai/deploy/core/app_context.py
+++ b/monai/deploy/core/app_context.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2023 MONAI Consortium
+# Copyright 2021-2025 MONAI Consortium
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -14,6 +14,7 @@ from os.path import abspath
 from typing import Dict, List, Optional
 
 from .arg_parser import parse_args, set_up_logging
+from .models import TritonModel
 from .models.factory import ModelFactory
 from .models.model import Model
 from .runtime_env import RuntimeEnv
@@ -45,6 +46,14 @@ class AppContext(object):
         # If model has not been loaded, or the model path has changed, get the path and load model(s)
         old_model_path = self.model_path
         self.model_path = args.get("model") or self.args.get("model") or self.runtime_env.model
+
+        # This parameter must be set if models are hosted on the Triton Inference Server.
+        self.triton_server_netloc = (
+            args.get("triton_server_netloc")
+            or self.args.get("triton_server_netloc")
+            or self.runtime_env.triton_server_netloc
+        )
+
         if old_model_path != self.model_path:
             self._model_loaded = False  # path changed, reset the flag to re-load
 
@@ -52,10 +61,19 @@ class AppContext(object):
             self.models: Optional[Model] = ModelFactory.create(abspath(self.model_path))
             self._model_loaded = True
 
+        # TritonModel instances are just clients and must be connected to the Triton Inference Server
+        # at the provided network location. In-process hosting of Triton Inference Server is not supported.
+        if self.triton_server_netloc:
+            for _, model in self.models.items():
+                if isinstance(model, TritonModel):
+                    model.connect(self.triton_server_netloc, verbose=args.get("log_level", "INFO") == "DEBUG")
+                    # Health check of the Triton Inference Server can be deferred.
+                    logging.info(f"Model {model.name} set to connect to Triton server at {self.triton_server_netloc}")
+
     def __repr__(self):
         return (
             f"AppContext(input_path={self.input_path}, output_path={self.output_path}, "
-            f"model_path={self.model_path}, workdir={self.workdir})"
+            f"model_path={self.model_path}, workdir={self.workdir}), triton_server_netloc={self.triton_server_netloc}"
         )
 
 

--- a/monai/deploy/core/arg_parser.py
+++ b/monai/deploy/core/arg_parser.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2023 MONAI Consortium
+# Copyright 2021-2025 MONAI Consortium
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/monai/deploy/core/arg_parser.py
+++ b/monai/deploy/core/arg_parser.py
@@ -64,7 +64,15 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
         type=argparse_types.valid_dir_path,
         help="Path to workspace folder (default: A temporary '.monai_workdir' folder in the current folder)",
     )
+    parser.add_argument(
+        "--triton-server-netloc",
+        "-t",
+        type=str,
+        default=None,
+        help="Triton server netloc, <host>:<port>. (default: None)",
+    )
 
+    # triton_server_netloc
     args = parser.parse_args(argv[1:])
     args.argv = argv  # save argv for later use in runpy
 

--- a/monai/deploy/core/models/__init__.py
+++ b/monai/deploy/core/models/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 MONAI Consortium
+# Copyright 2021-2025 MONAI Consortium
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/monai/deploy/core/models/__init__.py
+++ b/monai/deploy/core/models/__init__.py
@@ -23,6 +23,6 @@ from .factory import ModelFactory
 from .model import Model
 from .named_model import NamedModel
 from .torch_model import TorchScriptModel
-from .triton_model import TritonModel
+from .triton_model import TritonModel, TritonRemoteModel
 
 Model.register([TritonModel, NamedModel, TorchScriptModel, Model])

--- a/monai/deploy/core/models/model.py
+++ b/monai/deploy/core/models/model.py
@@ -81,7 +81,7 @@ class Model:
         else:
             self._name = Path(path).stem
 
-        self._predictor = None
+        self._predictor: Any = None
 
         # Add self to the list of models
         self._items: Dict[str, Model] = {self.name: self}

--- a/monai/deploy/core/models/model.py
+++ b/monai/deploy/core/models/model.py
@@ -1,4 +1,4 @@
-# Copyright 2021 MONAI Consortium
+# Copyright 2021-2025 MONAI Consortium
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/monai/deploy/core/models/named_model.py
+++ b/monai/deploy/core/models/named_model.py
@@ -12,9 +12,7 @@
 import logging
 from pathlib import Path
 
-from monai.deploy.core.models import ModelFactory
-
-from .model import Model
+from monai.deploy.core.models import Model, ModelFactory
 
 logger = logging.getLogger(__name__)
 

--- a/monai/deploy/core/models/named_model.py
+++ b/monai/deploy/core/models/named_model.py
@@ -1,4 +1,4 @@
-# Copyright 2021 MONAI Consortium
+# Copyright 2021-2025 MONAI Consortium
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -58,8 +58,12 @@ class NamedModel(Model):
 
         for model_folder in model_path.iterdir():
             if model_folder.is_dir():
-                # Pick one file (assume that only one file exists in the folder)
+                # Pick one file (assume that only one file exists in the folder), except for Triton model
                 model_file = next(model_folder.iterdir())
+                # If Triton model, then use the current folder
+                if (model_folder / "config.pbtxt").exists():
+                    model_file = model_folder
+
                 if model_file:
                     # Recursive call to identify the model type
                     model = ModelFactory.create(str(model_file), model_folder.name)
@@ -81,10 +85,14 @@ class NamedModel(Model):
 
         for model_folder in model_path.iterdir():
             # 3) Each model folder must contain only one model definition file or folder.
-            if sum(1 for _ in model_folder.iterdir()) != 1:
+            #    This would not be confused with Trion model repository which would have
+            #    folders for named models which in turn contain at least one version folder
+            #    and the config.pbtxt file.
+            #    However, with detecting config.pbtxt, Triton model repository can also be accepted.
+            if sum(1 for _ in model_folder.iterdir()) != 1 and not (model_folder / "config.pbtxt").exists():
                 logger.warning(
-                    f"Model repository {model_folder!r} contains more than one model definition file or folder "
-                    "so not treated as NamedModel."
+                    f"Model repository {model_folder!r} contains more than one model definition file or folder, "
+                    "and is not a Triton model repository, so not treated as NamedModel."
                 )
                 return False, None
 

--- a/monai/deploy/core/models/triton_model.py
+++ b/monai/deploy/core/models/triton_model.py
@@ -51,7 +51,7 @@ def parse_triton_config_pbtxt(pbtxt_path) -> ModelConfig:
             return model_config
 
     except Exception as e:
-        raise ValueError(f"Failed to parse config file {pbtxt_path}: {str(e)}")
+        raise ValueError(f"Failed to parse config file {pbtxt_path}") from e
 
 
 class TritonModel(Model):

--- a/monai/deploy/core/models/triton_model.py
+++ b/monai/deploy/core/models/triton_model.py
@@ -11,6 +11,7 @@
 
 import logging
 from pathlib import Path
+from typing import Tuple
 
 import tritonclient.http as httpclient
 from google.protobuf import text_format
@@ -263,7 +264,7 @@ class TritonModel(Model):
         self._predictor = predictor
 
     @classmethod
-    def accept(cls, path: str) -> tuple[bool, str]:
+    def accept(cls, path: str) -> Tuple[bool, str]:
         model_folder: Path = Path(path)
 
         # The path should be a folder path, for an individual model, and must have the config.pbtxt file.

--- a/monai/deploy/core/models/triton_model.py
+++ b/monai/deploy/core/models/triton_model.py
@@ -117,9 +117,9 @@ class TritonModel(Model):
         """
         super().__init__(path, name)
 
-        model_path: Path = Path(path)
-        self._name = model_path.stem
-        self._model_config = parse_triton_config_pbtxt(model_path / "config.pbtxt")
+        self._model_path: Path = Path(path)
+        self._name = self._model_path.stem
+        self._model_config = parse_triton_config_pbtxt(self._model_path / "config.pbtxt")
         # The model name in the config.pbtxt, if present, must match the model folder name.
         if self._model_config.name and self._model_config.name.casefold() != self._name.casefold():
             raise ValueError(
@@ -154,7 +154,7 @@ class TritonModel(Model):
     @property
     def model_config(self):
         if not self._model_config:  # not expected to happen with the current implementation.
-            self._model_config = parse_triton_config_pbtxt(self.path / "config.pbtxt")
+            self._model_config = parse_triton_config_pbtxt(self._model_path / "config.pbtxt")
         return self._model_config
 
     @property
@@ -171,24 +171,6 @@ class TritonModel(Model):
 
     @classmethod
     def accept(cls, path: str) -> tuple[bool, str]:
-        return cls.accept_local(path)
-
-    @classmethod
-    def accept_remote(cls, path: str) -> tuple[bool, str]:
-        # Check if the path is a valid Triton URL and also if the server is live
-        # This function is not yet fully implemneted or used, as it is meant to be used for
-        # dynamically querying the server for the model config instead of the local config.pbtxt file.
-        if path and not bool(re.search(r"\s", path)) and not Path(path).is_dir():
-            # Let's assume that the path is a url netloc, but
-            # for host:port, urlparse will parse it to
-            # (scheme='localhost', netloc='', path='80', params='', query='', fragment='')
-            # and for host only, path='localhost'
-            url = urlparse(path)
-            if url.scheme or url.path or url.netloc:
-                return True, cls.model_type
-
-    @classmethod
-    def accept_local(cls, path: str) -> tuple[bool, str]:
         model_folder: Path = Path(path)
 
         # The path should be a folder path, for an individual model, and must have the config.pbtxt file.

--- a/monai/deploy/core/models/triton_model.py
+++ b/monai/deploy/core/models/triton_model.py
@@ -1,4 +1,4 @@
-# Copyright 2021 MONAI Consortium
+# Copyright 2021-2025 MONAI Consortium
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -9,9 +9,49 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+import re
 from pathlib import Path
+from urllib.parse import urlparse
+
+import tritonclient.http as httpclient
+from google.protobuf import text_format
+from tritonclient.grpc.model_config_pb2 import DataType, ModelConfig
+
+from monai.deploy.utils.importutil import optional_import
 
 from .model import Model
+
+torch, _ = optional_import("torch")
+
+
+def parse_triton_config_pbtxt(pbtxt_path) -> ModelConfig:
+    """Parse a Triton model config.pbtxt file
+
+    Args:
+        config_path: Path to the config.pbtxt file
+
+    Returns:
+        ModelConfig object containing parsed configuration
+
+    Raises:
+        ValueError: If config file is invalid or missing required fields
+        FileNotFoundError: If config file doesn't exist
+    """
+
+    if not pbtxt_path.exists():
+        raise FileNotFoundError(f"Config file not found: {pbtxt_path}")
+    try:
+        # Read the config.pbtxt content
+        with open(pbtxt_path, "r") as f:
+            config_text = f.read()
+            # Parse using protobuf text_format
+            model_config = ModelConfig()
+            text_format.Parse(config_text, model_config)
+            return model_config
+
+    except Exception as e:
+        raise ValueError(f"Failed to parse config file {pbtxt_path}: {str(e)}")
 
 
 class TritonModel(Model):
@@ -45,19 +85,23 @@ class TritonModel(Model):
 
     1) The path should be a folder path.
 
-    2) The directory should contain only sub folders (model folders).
-
-    3) Each model folder must contain a config.pbtxt file.
+    2) The model folder must contain a config.pbtxt file.
 
        a. A config.pbtxt file may contain model name.
           In that case, model's name should match with the folder name.
 
-    4) Each model folder must include one or more folders having a positive integer value as name.
+    3) The model folder may include one or more folders having a positive integer value as version.
+       For the server side, the following is required, however, not required for the client side
+       which parses only the model config.pbtxt file.
 
-       a. Each such folder must contain a folder or file whose file name (without extension) is 'model'.
+       a. Each such folder must contain a folder or file whose file name (without extension) is 'model',
+          unless an attribute is used to specify model file name.
 
-    It currently doesn't identify which model version would be selected.
+    If no version policy is specified, the latest version of a model is loaded and served.
     Model items identified would have a folder path, not a specific model file path.
+
+    This class encapuslates a single triton model. As such, the model repository folder
+    will first be parsed by the named_model class, and then each sub folder by this class.
     """
 
     model_type: str = "triton"
@@ -73,50 +117,183 @@ class TritonModel(Model):
         """
         super().__init__(path, name)
 
-        # Clear existing model item and fill model items
-        self._items.clear()
         model_path: Path = Path(path)
+        self._name = model_path.stem
+        self._model_config = parse_triton_config_pbtxt(model_path / "config.pbtxt")
+        # The model name in the config.pbtxt, if present, must match the model folder name.
+        if self._model_config.name and self._model_config.name.casefold() != self._name.casefold():
+            raise ValueError(
+                f"Model name in config.pbtxt ({self._model_config.name}) does not match the folder name ({self._name})."
+            )
 
-        for model_folder in model_path.iterdir():
-            if model_folder.is_dir():
-                self._items[model_folder.name] = Model(str(model_folder), model_folder.name)
+        self._netloc = None  # network location of the Triton Inference Server
+        self._predictor = None  # triton remote client
+
+        logging.info(f"Created Triton model: {self._name}")
+
+    def connect(self, netloc: str, **kwargs):
+        """Connect to the Triton Inference Server at the network location.
+
+        Args:
+            netloc (str): The network location of the Triton Inference Server.
+        """
+
+        if not netloc:
+            if not self._predictor:
+                raise ValueError("Network location is required to connect to the Triton Inference Server.")
+            else:
+                logging.warning("No network location provided, using the last connected network location.")
+
+        if self._predictor and not self._netloc.casefold() == netloc.casefold():
+            logging.warning(f"Reconnecting to a different Triton Inference Server at {netloc} from {self._netloc}.")
+
+        self._netloc = netloc
+        self._predictor = TritonRemoteModel(self._name, self._netloc, self._model_config, **kwargs)
+        return self._predictor
+
+    @property
+    def model_config(self):
+        if not self._model_config:  # not expected to happen with the current implementation.
+            self._model_config = parse_triton_config_pbtxt(self.path / "config.pbtxt")
+        return self._model_config
+
+    @property
+    def predictor(self):
+        """Get the model's predictor (triton remote client)
+
+        Returns:
+            the model's predictor
+        """
+        if self._predictor is None:
+            raise ValueError("Model is not connected to the Triton Inference Server.")
+
+        return self._predictor
 
     @classmethod
-    def accept(cls, path: str):
-        model_path: Path = Path(path)
+    def accept(cls, path: str) -> tuple[bool, str]:
+        return cls.accept_local(path)
 
-        # 1) The path should be a folder path.
-        if not model_path.is_dir():
-            return False, None
+    @classmethod
+    def accept_remote(cls, path: str) -> tuple[bool, str]:
+        # Check if the path is a valid Triton URL and also if the server is live
+        # This function is not yet fully implemneted or used, as it is meant to be used for
+        # dynamically querying the server for the model config instead of the local config.pbtxt file.
+        if path and not bool(re.search(r"\s", path)) and not Path(path).is_dir():
+            # Let's assume that the path is a url netloc, but
+            # for host:port, urlparse will parse it to
+            # (scheme='localhost', netloc='', path='80', params='', query='', fragment='')
+            # and for host only, path='localhost'
+            url = urlparse(path)
+            if url.scheme or url.path or url.netloc:
+                return True, cls.model_type
 
-        # 2) The directory should contain only sub folders (model folders).
-        if not all((p.is_dir() for p in model_path.iterdir())):
-            return False, None
+    @classmethod
+    def accept_local(cls, path: str) -> tuple[bool, str]:
+        model_folder: Path = Path(path)
 
-        is_triton_model_repository = True
-        for model_folder in model_path.iterdir():
-            # 3) Each model folder must contain a config.pbtxt file.
-            if not (model_folder / "config.pbtxt").exists():
-                return False, None
-            # TODO(gigony): We do not check if the config.pbtxt file contains model name for now (3-1).
-            # We assume that the model name is the same as the folder name.
+        # The path should be a folder path, for an individual model, and must have the config.pbtxt file.
+        if not model_folder.is_dir() or not (model_folder / "config.pbtxt").exists():
+            return False, ""
 
-            # 4) Each model folder must include one or more folders having a positive integer value as name.
-            found_model = False
-            for version_folder in model_folder.iterdir():
-                version_folder_name = version_folder.name
-                if version_folder.is_dir() and version_folder_name.isnumeric() and int(version_folder_name) > 0:
-                    # 4-1) Each such folder must contain a folder or file whose file name (without extension)
-                    #      is 'model'.
-                    # TODO(gigony): check config.pbtxt file to see actual model file if specified.
-                    if any(version_folder.glob("model.*")):
-                        found_model = True
-                    else:
-                        return False, None
-            if not found_model:
-                is_triton_model_repository = False
-                break
-        if is_triton_model_repository:
-            return True, cls.model_type
+        # Delay parsing the config.pbtxt protobuf for model name, input and output information etc.
+        # Per convention, the model name is the same as the folder name, and the name in the config file,
+        # if specified, must match the folder name.
+        # For the server, each model folder must include one or more folders having a positive integer value as name,
+        # and each such folder must contain a folder or file for the model.
+        # At the client side, though there is no need to have the actual model file.
+        # So the following is not necessary at all, just checking for logging purpose.
+        found_model = False
+        for version_folder in model_folder.iterdir():
+            version_folder_name = version_folder.name
+            if version_folder.is_dir() and version_folder_name.isnumeric() and int(version_folder_name) > 0:
+                # Each such folder must contain a folder or file whose file name (without extension)
+                #      is 'model'. The config.pbtxt can specify the actual model file with an attribute.
+                if any(version_folder.glob("*")):
+                    found_model = True
+                    logging.info(f"Model {model_folder.name} version {version_folder_name} found in client workspace.")
+        if not found_model:
+            logging.info(f"Model {model_folder.name} only has config.pbtxt in client workspace.")
 
-        return False, None
+        return True, cls.model_type
+
+
+class TritonRemoteModel:
+    """A remote model that is hosted on a Triton Inference Server.
+
+    Args:
+        model_name (str): The name of the model.
+        netloc (str): The network location of the Triton Inference Server.
+        model_config (ModelConfig): The model config.
+        headers (dict): The headers to send to the Triton Inference Server.
+    """
+
+    def __init__(self, model_name, netloc, model_config, headers=None, **kwargs):
+        self._headers = headers
+        self._request_compression_algorithm = None
+        self._response_compression_algorithm = None
+        self._model_name = model_name
+        self._model_version = None
+        self._model_config = model_config
+        self._request_compression_algorithm = None
+        self._response_compression_algorithm = None
+        self._count = 0
+
+        try:
+            self._triton_client = httpclient.InferenceServerClient(url=netloc, verbose=kwargs.get("verbose", False))
+            print(f"Created triton client: {self._triton_client}")
+        except Exception as e:
+            logging.error("channel creation failed: " + str(e))
+            raise
+
+    def __call__(self, data, **kwds):
+
+        self._count += 1
+        logging.info(f"{self.__class__.__name__}.__call__: {self._model_name} count: {self._count}")
+
+        inputs = []
+        outputs = []
+
+        # For now support only one input and one output
+        input_name = self._model_config.input[0].name
+        input_type = str.split(DataType.Name(self._model_config.input[0].data_type), "_")[1]  # remove the prefix
+        input_shape = list(self._model_config.input[0].dims)
+        data_shape = list(data.shape)
+        logging.info(f"Model config input data shape: {input_shape}")
+        logging.info(f"Actual input data shape: {data_shape}")
+
+        # The server side will handle the batching, and with dynamic batching
+        # the model config does not have the batch size in the input dims.
+        logging.info(f"Effective input_name: {input_name}, input_type: {input_type}, input_shape: {data_shape}")
+
+        inputs.append(httpclient.InferInput(input_name, data_shape, input_type))
+
+        # Move to tensor to CPU
+        input0_data_np = data.detach().cpu().numpy()
+        logging.debug(f"Input data shape: {input0_data_np.shape}")
+
+        # Initialize the data
+        inputs[0].set_data_from_numpy(input0_data_np, binary_data=False)
+
+        output_name = self._model_config.output[0].name
+        outputs.append(httpclient.InferRequestedOutput(output_name, binary_data=True))
+
+        query_params = {f"{self._model_name}_count": self._count}
+        results = self._triton_client.infer(
+            self._model_name,
+            inputs,
+            outputs=outputs,
+            query_params=query_params,
+            headers=self._headers,
+            request_compression_algorithm=self._request_compression_algorithm,
+            response_compression_algorithm=self._response_compression_algorithm,
+        )
+
+        logging.info(f"Got results{results.get_response()}")
+        output0_data = results.as_numpy(output_name)
+        logging.debug(f"as_numpy output0_data.shape: {output0_data.shape}")
+        logging.debug(f"as_numpy output0_data.dtype: {output0_data.dtype}")
+
+        # Convert numpy array to torch tensor as expected by the anticipated clients,
+        # e.g. monai cliding window inference
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        return torch.as_tensor(output0_data).to(device)  # from_numpy is fine too.

--- a/monai/deploy/core/models/triton_model.py
+++ b/monai/deploy/core/models/triton_model.py
@@ -10,9 +10,7 @@
 # limitations under the License.
 
 import logging
-import re
 from pathlib import Path
-from urllib.parse import urlparse
 
 import tritonclient.http as httpclient
 from google.protobuf import text_format

--- a/monai/deploy/core/runtime_env.py
+++ b/monai/deploy/core/runtime_env.py
@@ -1,4 +1,4 @@
-# Copyright 2021 MONAI Consortium
+# Copyright 2021-2025 MONAI Consortium
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -17,8 +17,10 @@ from typing import Dict, Optional, Tuple
 class RuntimeEnv(ABC):
     """Class responsible for managing run time settings.
 
-    The expected environment variables are the keys in the defaults dictionary,
-    and they can be set to override the defaults.
+    The expected variables can be set via the host env vars which override the
+    default values in the internal dictionary.
+    Selective overriding of variables can be done by passing a dictionary to the constructor,
+    which should have the same structure as the internal dictionary.
     """
 
     ENV_DEFAULT: Dict[str, Tuple[str, ...]] = {
@@ -26,15 +28,21 @@ class RuntimeEnv(ABC):
         "output": ("HOLOSCAN_OUTPUT_PATH", "output"),
         "model": ("HOLOSCAN_MODEL_PATH", "models"),
         "workdir": ("HOLOSCAN_WORKDIR", ""),
+        "triton_server_netloc": ("TRITON_SERVER_NETLOC", ""),
     }
 
+    # Place holders as the values will be set in the __init__ method
     input: str = ""
     output: str = ""
     model: str = ""
     workdir: str = ""
+    triton_server_netloc: str = ""  # Triton server host:port
 
     def __init__(self, defaults: Optional[Dict[str, Tuple[str, ...]]] = None):
         if defaults is None:
             defaults = self.ENV_DEFAULT
+        else:
+            defaults = {**self.ENV_DEFAULT, **defaults}
+
         for key, (env, default) in defaults.items():
             self.__dict__[key] = os.environ.get(env, default)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 holoscan~=2.0
 numpy>=1.21.6
 colorama>=0.4.1
+tritonclient>=2.42.0 # released 2024-01-29
 typeguard>=3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 holoscan~=2.0
 numpy>=1.21.6
 colorama>=0.4.1
-tritonclient[all]>=2.54.0 # released 2025-01-29
+tritonclient[all]
 typeguard>=3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 holoscan~=2.0
 numpy>=1.21.6
 colorama>=0.4.1
-tritonclient>=2.42.0 # released 2024-01-29
+tritonclient[all]>=2.54.0 # released 2025-01-29
 typeguard>=3.0.0


### PR DESCRIPTION
This pull request adds support for performing inference on remote Triton Inference Server, with ease of use
- updated the TritonModel class to fully support and encapsulate the Triton client of the specific model hosted in Triton Inference Server. This is done by parsing the key elements of Triton model config.pbtxt file (actual model files not required), and dynamically setting the input and output parameters using the parsed model configurations. User app is relived from setting any arguments except for the server network location, and in future versions, TLS keys for secure communication.
- enhanced the NamedModel to include the support of Triton model repository (which may have multiple folders each for a specific model), making it possible to support hybrid inference scenario, i.e. local in-proc hosted as well as Triton hosted models, all transparent to the user app.
- updated the app context class to support the setting for Triton server network location, as well as calling the instantiated TritonModel to connect to the remote server.
- Added and tested example app showcasing remote inference on Triton Inference Server.

Also added the following files to the example application folder:
- Example Triton Model repo for the client side, i.e. with only model folder and its config.pbtxt file.
- Example Shell script to set the required env vars, though if these are not set, the command line option can be used instead.

The Quality Gate failure is due to the example app has duplicated code, which is true as it has exactly the same app inference operator as the Spleen Seg app with in-proc Torch model hosting. We have each example app folder contain all necessary code for ease of use, hence have to tolerate the duplicates with a few hundred lines of code.   
      