### PR TITLE
MONAISegInferenceOperator Additional Arguments

### DIFF
--- a/monai/deploy/core/__init__.py
+++ b/monai/deploy/core/__init__.py
@@ -30,7 +30,7 @@
 
 # Need to import explicit ones to quiet mypy complaints
 from holoscan.core import *
-from holoscan.core import Application, Condition, ConditionType, Fragment, Operator, OperatorSpec
+from holoscan.core import Application, Condition, ConditionType, Fragment, Operator, OperatorSpec, Resource
 
 from .app_context import AppContext, init_app_context
 from .arg_parser import parse_args

--- a/monai/deploy/core/__init__.py
+++ b/monai/deploy/core/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 MONAI Consortium
+# Copyright 2021-2025 MONAI Consortium
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/monai/deploy/operators/monai_seg_inference_operator.py
+++ b/monai/deploy/operators/monai_seg_inference_operator.py
@@ -121,25 +121,21 @@ class MonaiSegInferenceOperator(InferenceOperator):
             # Drop explicitly defined kwargs
             if name in init_params or name in explicit_used:
                 logger.warning(f"{name!r} is already explicitly defined or used; dropping kwarg.")
-                continue
             # SWI params
             elif name in swi_params:
                 filtered_swi_params[name] = val
                 logger.debug(f"{name!r} used in sliding_window_inference; keeping kwarg for inference call.")
-                continue
             # Drop kwargs that can't be converted by Holoscan
             elif not isinstance(val, allowed_types):
                 logger.warning(
                     f"{name!r} type of {type(val).__name__!r} is a non-convertible kwarg for Holoscan; dropping kwarg."
                 )
-                continue
             # Base __init__ params
             else:
                 filtered_base_init_params[name] = val
                 logger.debug(
                     f"{name!r} type of {type(val).__name__!r} can be converted by Holoscan; keeping kwarg for base init."
                 )
-                continue
         return filtered_swi_params, filtered_base_init_params
 
     def __init__(


### PR DESCRIPTION
When translating the [MONAI CT TotalSegmentator MONAI Bundle](https://github.com/Project-MONAI/model-zoo/tree/dev/models/wholeBody_ct_segmentation) to a MAP, it was determined that the segmentations produced by the MONAI Bundle and MAP were not exactly aligned (i.e. DICE != 1 for all organs).

This seems to be due to the `MONAISegInferenceOperator` not accepting all the possible arguments that are accepted by the [sliding_window_inference](https://github.com/Project-MONAI/MONAI/blob/d388d1c6fec8cb3a0eebee5b5a0b9776ca59ca83/monai/inferers/utils.py#L42) method, specifically `mode` and `padding_mode` for this Bundle. Once a custom operator that accepted these input arguments was implemented into the MAP pipeline, the DICE for all organs was ~=0.99 when comparing to the Bundle.

This initial commit includes the logic for accepting and implementing `mode` and `padding_mode` arguments. Happy to discuss further if the additional missing `sliding_window_inference` arguments should be added as well.