### PR TITLE
Bump version: 3.0.0 → 3.1.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.0.0
+current_version = 3.1.0
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<release>a|b|rc)(?P<build>\d+))?
 serialize = 
 	{major}.{minor}.{patch}{release}{build}


### PR DESCRIPTION
Releasing v3.1.0.

The branch name mistakenly states 3.0, but it is from 3.1.0 release.