### PR TITLE
Add README to the remote inference example app

### DIFF
--- a/examples/apps/ai_remote_infer_app/README.md
+++ b/examples/apps/ai_remote_infer_app/README.md
@@ -5,7 +5,7 @@ This example application demonstrates how to perform medical image segmentation 
 ## Overview
 
 This application showcases:
-- **Remote inference using Triton Inference Server**: The app connects to a Triton server to perform model inference remotely rather than loading models locally, by sending and receiving input/output tensors corresponding to the model dimensions including channels
+- **Remote inference using Triton Inference Server**: The app connects to a Triton server to perform model inference remotely rather than loading models locally. It communicates by sending and receiving input/output tensors corresponding to the model dimensions, including channels.
 - **Triton client integration**: The built-in `TritonRemoteModel` class is provided in the [triton_model.py](https://github.com/Project-MONAI/monai-deploy-app-sdk/blob/137ac32d647843579f52060c8f72f9d9e8b51c38/monai/deploy/core/models/triton_model.py) module. This class acts as a Triton inference client, communicating with an already loaded model network on the server. It supports the same API as the in-process model class (e.g., a loaded TorchScript model network). As a result, the application inference operator does not need to change when switching between in-process and remote inference.
 - **Model metadata parsing**: Uses Triton's model folder structure, which contains the `config.pbtxt` configuration file, to extract model specifications including name, input/output dimensions, and other metadata.
 - **Model path requirement**: The parent folder of the Triton model folder needs to be used as the model path for the application.


### PR DESCRIPTION
This PR adds comprehensive documentation for the AI remote inference example application, specifically for spleen segmentation using Triton Inference Server. The README provides detailed guidance on how to use MONAI Deploy SDK with remote inference capabilities.

Adds a complete README.md file documenting the remote inference example application
Documents Triton server integration patterns and API compatibility between local and remote inference
Provides setup instructions, configuration details, and usage examples for the spleen segmentation app