### PR TITLE
nvImageCodec JPEGLossless 9-15 bit Guard

### DIFF
--- a/monai/deploy/operators/decoder_nvimgcodec.py
+++ b/monai/deploy/operators/decoder_nvimgcodec.py
@@ -14,7 +14,14 @@ This decoder plugin for nvimgcodec <https://github.com/NVIDIA/nvImageCodec> deco
 encoded Pixel Data for the following transfer syntaxes:
     JPEGBaseline8Bit, 1.2.840.10008.1.2.4.50, JPEG Baseline (Process 1)
     JPEGLossless, 1.2.840.10008.1.2.4.57, JPEG Lossless, Non-Hierarchical (Process 14)
+        NOTE: 9 <= BitsStored <= 15 is NOT supported by nvimgcodec (nvjpeg GPU kernel silently
+        returns zeros for SOF3 streams with P in this range). BitsStored=8 is handled correctly
+        by nvimgcodec via its internal self-rejection (UINT8 output is unsupported by the lossless
+        backend, so it falls through cleanly). Frames with 9 <= BitsStored <= 15 are automatically
+        routed to the next capable decoder. See https://github.com/NVIDIA/nvImageCodec.
     JPEGLosslessSV1, 1.2.840.10008.1.2.4.70, JPEG Lossless, Non-Hierarchical, First-Order Prediction
+        NOTE: 9 <= BitsStored <= 15 is NOT supported by nvimgcodec (same limitation as above).
+        Frames with 9 <= BitsStored <= 15 are automatically routed to the next capable decoder.
     JPEG2000Lossless, 1.2.840.10008.1.2.4.90, JPEG 2000 Image Compression (Lossless Only)
     JPEG2000, 1.2.840.10008.1.2.4.91, JPEG 2000 Image Compression
     HTJ2KLossless, 1.2.840.10008.1.2.4.201, HTJ2K Image Compression (Lossless Only)
@@ -42,7 +49,7 @@ A custom decoding plugin must implement three objects within the same module:
       This will be used to provide the user with a list of dependencies required by the plugin.
  - A function that performs the decoding with the following function signature as in Github repo:
     def _decode_frame(src: bytes, runner: DecodeRunner) -> bytearray | bytes
-      src is a single frame’s worth of raw compressed data to be decoded, and
+      src is a single frame's worth of raw compressed data to be decoded, and
       runner is a DecodeRunner instance that manages the decoding process.
 
 Adding plugins to a Decoder:
@@ -129,6 +136,26 @@ SUPPORTED_TRANSFER_SYNTAXES: Iterable[UID] = [x.UID for x in SUPPORTED_DECODER_C
 
 _logger = logging.getLogger(__name__)
 
+# Transfer syntaxes that use JPEG Lossless (SOF3) encoding, where sub-16-bit precision
+# causes nvjpeg to silently zero-fill the output buffer
+_JPEG_LOSSLESS_SYNTAXES = (JPEGLosslessDecoder.UID, JPEGLosslessSV1Decoder.UID)
+
+# Set of (tsyntax_str, bits_stored) pairs already warned about; prevents repeated per-frame warnings
+_BITS_STORED_FALLBACK_WARNED: set = set()
+
+# Set of (tsyntax_str, dtype_str) pairs already logged at INFO; subsequent frames log at DEBUG only
+_DECODE_SUCCESS_LOGGED: set = set()
+
+
+class _SuppressFallbackFilter(logging.Filter):
+    """Filter installed on pydicom.pixels.decoders.base to suppress per-frame ERROR logs
+    that pydicom emits whenever a decoder plugin raises NotImplementedError.  We emit a single
+    WARNING ourselves instead, so the repeated ERROR+traceback output is just noise.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:  # noqa: A003
+        return "nvimgcodec does not reliably decode" not in record.getMessage()
+
 
 # Lazy singleton for nvimgcodec decoder; initialized on first use
 # Decode params are created per-decode based on image characteristics
@@ -179,6 +206,33 @@ def _decode_frame(src: bytes, runner: DecodeRunner) -> bytearray | bytes:
     if not is_available(tsyntax):
         raise ValueError(f"Transfer syntax {tsyntax} not supported; see details in the debug log.")
 
+    # nvimgcodec silently returns zero-filled buffers for JPEG Lossless (SOF3) streams
+    # where 9 <= BitsStored <= 15, e.g. Philips scanners with BitsStored=12
+    #
+    # BitsStored=8 does NOT need this guard: nvimgcodec's lossless decoder internally
+    # rejects UINT8 output (it only supports UINT16), so it falls through to libjpeg-turbo
+    # cleanly without ever calling nvjpegDecodeBatched.  Only the 9-15 range reaches the
+    # buggy nvjpegDecodeBatched path that zero-fills silently
+    #
+    # Raise NotImplementedError so pydicom falls through to the next capable decoder
+    if tsyntax in _JPEG_LOSSLESS_SYNTAXES and 9 <= runner.bits_stored <= 15:
+        warn_key = (str(tsyntax), runner.bits_stored)
+        if warn_key not in _BITS_STORED_FALLBACK_WARNED:
+            _BITS_STORED_FALLBACK_WARNED.add(warn_key)
+            _logger.warning(
+                f"nvimgcodec does not support {tsyntax} with BitsStored={runner.bits_stored} (9-15); "
+                "falling back to non-nvimgcodec decoder for this series"
+            )
+            # Suppress the per-frame ERROR+traceback that pydicom.pixels.decoders.base emits
+            # whenever a plugin raises NotImplementedError — we already logged one warning above
+            _pydicom_base_logger = logging.getLogger("pydicom.pixels.decoders.base")
+            if not any(isinstance(f, _SuppressFallbackFilter) for f in _pydicom_base_logger.filters):
+                _pydicom_base_logger.addFilter(_SuppressFallbackFilter())
+        raise NotImplementedError(
+            f"nvimgcodec does not reliably decode {tsyntax} with BitsStored={runner.bits_stored} (9-15); "
+            "falling back to non-nvimgcodec decoder for this series"
+        )
+
     # runner.set_frame_option(runner.index, "decoding_plugin", NVIMGCODEC_PLUGIN_LABEL)  # type: ignore[attr-defined]
     # in pydicom v3.1.0 can use the above call, but do we want to limit to this plugin?
     is_jpeg2k = tsyntax in JPEG2000TransferSyntaxes
@@ -218,6 +272,11 @@ def _decode_frame(src: bytes, runner: DecodeRunner) -> bytearray | bytes:
             else f"Set photometric_interpretation to RGB for {photometric_interpretation}"
         )
 
+    log_key = (str(tsyntax), str(np_surface.dtype))
+    if log_key not in _DECODE_SUCCESS_LOGGED:
+        _DECODE_SUCCESS_LOGGED.add(log_key)
+        _logger.info(f"nvimgcodec decoding active: tsyntax={tsyntax} dtype={np_surface.dtype}")
+    _logger.debug(f"nvimgcodec decoded frame: tsyntax={tsyntax} shape={np_surface.shape} dtype={np_surface.dtype}")
     return np_surface.tobytes()
 
 

--- a/monai/deploy/operators/monet_bundle_inference_operator.py
+++ b/monai/deploy/operators/monet_bundle_inference_operator.py
@@ -12,11 +12,12 @@
 from typing import Any, Dict, Tuple, Union
 
 from monai.deploy.core import Image
-from monai.deploy.operators.monai_bundle_inference_operator import MonaiBundleInferenceOperator, get_bundle_config
-from monai.deploy.utils.importutil import optional_import
-from monai.transforms import ConcatItemsd, ResampleToMatch
 from monai.deploy.core.models.torch_model import TorchScriptModel
 from monai.deploy.core.models.triton_model import TritonModel
+from monai.deploy.operators.monai_bundle_inference_operator import MonaiBundleInferenceOperator
+from monai.deploy.utils.importutil import optional_import
+from monai.transforms import ConcatItemsd, ResampleToMatch
+
 torch, _ = optional_import("torch", "1.10.2")
 MetaTensor, _ = optional_import("monai.data.meta_tensor", name="MetaTensor")
 __all__ = ["MONetBundleInferenceOperator"]
@@ -88,7 +89,7 @@ class MONetBundleInferenceOperator(MonaiBundleInferenceOperator):
             for key in kwargs.keys():
                 if isinstance(kwargs[key], MetaTensor):
                     multimodal_data[key] = ResampleToMatch(mode="bilinear")(kwargs[key], img_dst=data)
-            data = ConcatItemsd(keys=list(multimodal_data.keys()), name="image")(multimodal_data)["image"]
+            data = ConcatItemsd(keys=list(multimodal_data.keys()), name="image")(multimodal_data)["image"]  # type: ignore[arg-type]
         if len(data.shape) == 4:
             data = data[None]
         prediction = self._nnunet_predictor(data)

--- a/tests/unit/test_decoder_nvimgcodec.py
+++ b/tests/unit/test_decoder_nvimgcodec.py
@@ -9,6 +9,7 @@ from pydicom import dcmread
 from pydicom.data import get_testdata_files
 
 from monai.deploy.operators.decoder_nvimgcodec import (
+    _JPEG_LOSSLESS_SYNTAXES,
     SUPPORTED_DECODER_CLASSES,
     SUPPORTED_TRANSFER_SYNTAXES,
     _is_nvimgcodec_available,
@@ -161,6 +162,19 @@ def test_nvimgcodec_decoder_matches_default(path: str) -> None:
 
     rtol = 0.01
     atol = 4.0
+
+    # Skip files with known nvimgcodec limitation: JPEG Lossless with 9 <= BitsStored <= 15
+    try:
+        _ds_meta = dcmread(path, stop_before_pixels=True)
+        _ts = _ds_meta.file_meta.TransferSyntaxUID
+        _bits_stored = getattr(_ds_meta, "BitsStored", 16)
+        if _ts in _JPEG_LOSSLESS_SYNTAXES and 9 <= _bits_stored <= 15:
+            pytest.skip(
+                f"Skipping {Path(path).name}: JPEG Lossless with BitsStored={_bits_stored} (9-15) "
+                "is not supported by nvimgcodec (intentional fallback)"
+            )
+    except Exception:
+        pass
 
     baseline_pixels: np.ndarray = np.array([])
     nv_pixels: np.ndarray = np.array([])


### PR DESCRIPTION
## Tighten `JPEGLossless` fallback guard to `9 <= BitsStored <= 15`

### Background

When testing MAPs built with `monai-deploy-app-sdk==3.5.0`, two cases (one CT, one MR) were identified that produced zero-segmentations after model processing. Both cases are from Philips scanners with `BitsStored = 12` and Transfer Syntax `JPEGLosslessSV1` (`1.2.840.10008.1.2.4.70`). Further investigation of these cases showed that `decoder_nvimgcodec.py` produced a zero-filled output image buffer - essentially a silent decoding error which propagates and manifests as an empty segmentation.

When testing older MAPs built with `monai-deploy-app-sdk==3.1.0` on these cases, non-zero segmentations are produced. Non-`nvImageCodec` decoders (e.g. `GDCM`) produce a non-zero-filled output image buffer.

See below existing `decoder_nvimgcodec.py` vs. `GDCM` behavior for one of the files in the CT case - the decoder pipeline log shows that `nvimgcodec` processes the file and produces a zero output buffer, instead of falling back to subsequent decoders like `GDCM`:

```bash
File  : IMG00233.dcm
       TS=1.2.840.10008.1.2.4.70  BitsAllocated=16  BitsStored=12
       [nvimgcodec decoder] decoded  shape=(512, 512, 1)  dtype=uint16  all_zero=True  <-- SILENT ZERO-FILL BUG
       [gdcm decoder     ] decoded  shape=(512, 512)  dtype=uint16  all_zero=False
       [decoder pipeline ] decoded  shape=(512, 512)  dtype=uint16  all_zero=True  [via nvimgcodec]  <-- ALL ZERO
       [comparison       ] MISMATCH  <-- PIXEL CORRUPTION  max_diff=2550  mean_diff=468.1005
```

There is a file that meets this same criteria (`BitsStored = 12`, Transfer Syntax `JPEGLosslessSV1` [`1.2.840.10008.1.2.4.70`]) in the `decoder_nvimgcodec` unit test suite - `bad_sequence.dcm`. `decoder_nvimgcodec.py` produces a non-zero image buffer after decoding.

### Per-File Analysis

All three files share `BitsStored=12` in their DICOM tags, yet produce different outcomes. The difference is entirely in the JPEG byte stream — specifically the SOF3 `P` byte and segment ordering — neither of which is visible to the Python decoder via `runner.bits_stored`.

| | `bad_sequence.dcm` | `MR.dcm` | `CT.dcm` |
|---|---|---|---|
| **Result** | ✅ nvimgcodec OK | ❌ Silent zeros | ❌ Silent zeros |
| **Bug triggered** | None | Bug 1: P≠16 | Bug 2: DHT before SOF3 |
| **Manufacturer** | Siemens | Philips | Philips |
| **Model** | SOMATOM Definition AS+ | Ingenia | iCT SP |
| **BitsStored (DICOM tag)** | 12 | 12 | 12 |
| **SOF3 P byte (actual)** | 16 | 12 | 16 |
| **Segment order** | SOI → SOF3(P=16) → DHT → SOS | SOI → SOF3(P=12) → DHT → SOS | SOI → COM → DHT → SOF3(P=16) → SOS |

**`bad_sequence.dcm` (Siemens — works):** Although `BitsStored=12` in the DICOM tag, Siemens writes `P=16` in the SOF3 header and uses standard segment ordering. From `nvjpeg`'s perspective this is a valid 16-bit lossless stream; it decodes correctly and produces a non-zero image. Note that writing `P=16` when `BitsStored=12` is itself non-conformant per DICOM (SOF3 `P` should equal `BitsStored`, but it happens to match what `nvjpeg` expects.)

**`MR.dcm` (Philips — Bug 1):** Philips writes `P=12` in the SOF3 header, correctly matching `BitsStored=12` per the DICOM standard. The `nvImageCodec` JPEG parser maps `P=12` to `UINT16` (any precision 9–16 maps to UINT16), so `canDecode` accepts the stream. However, `nvjpegDecodeBatched` internally assumes all UINT16 lossless streams are `P=16`. With `P=12` the Huffman-coded bitstream uses 12-bit samples; the GPU kernel misreads the entropy-coded data and silently writes zeros.

**`CT.dcm` (Philips — Bug 2):** Although `BitsStored=12` in the DICOM tag, Philips writes `P=16` in the SOF3 header but inserts a COM (comment) marker and a DHT (Huffman table) segment before SOF3 — non-standard ordering that is technically valid per ITU-T T.81 but not handled by `nvjpeg`. The `nvImageCodec` parser scans past COM and DHT to find SOF3, correctly reads `P=16`, and `canDecode` accepts the stream. However, `nvjpegDecodeBatched` has its own internal parser that expects SOF3 before DHT. Encountering DHT first, it fails to build the decode tables correctly and silently writes zeros.

Critically, `nvjpegDecodeBatchedSupported` returns "supported" for both Bug 1 and Bug 2 streams — this is the core defect that makes both failures silent.

### Root Cause

The `nvimgcodec` lossless JPEG decoder (`NVJPEG_BACKEND_LOSSLESS_JPEG`) silently produces zero-filled output buffers for certain JPEG Lossless (SOF3) DICOM frames. Investigation of the [nvImageCodec source](https://github.com/NVIDIA/nvImageCodec) identified two independent root causes, both in the closed-source `nvjpegDecodeBatched` binary:

1. **Sub-16-bit SOF3 precision (Bug 1):** When the SOF3 `P` byte encodes a precision of 9–15 (e.g. Philips scanners writing `P=12` for a 12-bit series), `nvjpegDecodeBatched` silently zero-fills the output buffer.

2. **DHT-before-SOF3 segment ordering (Bug 2):** When a Huffman table (DHT) segment appears before the SOF3 marker — non-standard but valid per ITU-T T.81, and emitted by some Philips scanners — `nvjpegDecodeBatched` again silently zero-fills. `nvjpegDecodeBatchedSupported` incorrectly returns "supported" in both cases, which is why the failures are silent.

Both failing files have `BitsStored=12` in the DICOM tag.

### Why BitsStored=8 does not need a guard

Source code analysis of `extensions/nvjpeg/lossless_decoder.cpp` and `src/parsers/jpeg.cpp` shows that for `P=8`, the JPEG parser maps precision to `NVIMGCODEC_SAMPLE_DATA_TYPE_UINT8`. The lossless decoder's `canDecode` function then explicitly rejects UINT8 output (it only supports UINT16), returning `SAMPLE_TYPE_UNSUPPORTED` before `nvjpegDecodeBatched` is ever called. The framework falls through cleanly to `libjpeg-turbo`, which decodes correctly. No silent zeros — no guard needed.

### Changes

- **Guard condition:** `runner.bits_stored < 16` → `9 <= runner.bits_stored <= 15`. This reflects the actual vulnerable range: only precision values that map to UINT16 (so `canDecode` accepts them) but are not 16-bit (so `nvjpegDecodeBatched` zero-fills).
- **`_JPEG_LOSSLESS_SYNTAXES`:** Promoted from a per-call tuple to a module-level constant.
- **Module docstring and warning messages:** Updated to accurately document the `9–15` range and explain why BitsStored=8 is handled correctly without a guard.
- **Updated nvimgcodec test set:** Removed `bad_sequence.dcm` until `nvImageCodec` fix implemented

### Upstream fix

The correct long-term fix is in `extensions/nvjpeg/lossless_decoder.cpp` in the nvImageCodec repo: `canDecode` should reject streams where `plane_info[0].precision` is not 0 or 16, and pre-scan for DHT-before-SOF3 ordering before calling `nvjpegJpegStreamParse`. This Python-layer guard is a workaround until that upstream fix is available.